### PR TITLE
fix: Added full ddl support for analysis.go and fix normalize ObjectName to unqualified across all actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ go get github.com/valkdb/postgresparser
 Handles the SQL you actually write in production:
 
 - **DML**: SELECT, INSERT, UPDATE, DELETE, MERGE
-- **DDL**: CREATE INDEX, DROP TABLE/INDEX, ALTER TABLE, TRUNCATE
+- **DDL**: CREATE TABLE (columns/type/nullability/default), CREATE INDEX, DROP TABLE/INDEX, ALTER TABLE, TRUNCATE
 - **CTEs**: `WITH ... AS` including `RECURSIVE`, materialization hints
 - **JOINs**: INNER, LEFT, RIGHT, FULL, CROSS, NATURAL, LATERAL
 - **Subqueries**: in SELECT, FROM, WHERE, and HAVING
@@ -63,6 +63,8 @@ Handles the SQL you actually write in production:
 - **Window functions**: OVER, PARTITION BY
 - **Type casts**: `::type`
 - **Parameters**: `$1`, `$2`, ...
+
+IR field reference: [ParsedQuery IR Reference](docs/parsed-query.md)
 
 ## Analysis
 
@@ -122,6 +124,10 @@ joins, _ := analysis.ExtractJoinRelationshipsWithSchema(
 // orders.customer_id → customers.id
 ```
 
+### DDL extraction
+
+For `CREATE TABLE` parsing, see [`examples/ddl/`](examples/ddl/).
+
 ## Performance
 
 With SLL prediction mode, `postgresparser` parses most queries in **70–350 µs** with minimal allocations. The IR extraction layer accounts for only ~3% of CPU — the rest is ANTLR's grammar engine, which SLL mode keeps fast.
@@ -134,6 +140,7 @@ See the [`examples/`](examples/) directory:
 
 - [`basic/`](examples/basic/) — Parse SQL and inspect the IR
 - [`analysis/`](examples/analysis/) — Column usage, WHERE conditions, JOIN relationships
+- [`ddl/`](examples/ddl/) — Parse CREATE TABLE / ALTER TABLE plus DELETE command metadata
 - [`sll_mode/`](examples/sll_mode/) — SLL prediction mode for maximum throughput
 
 ## Grammar

--- a/analysis/analysis.go
+++ b/analysis/analysis.go
@@ -334,11 +334,30 @@ func convertDDLActions(actions []postgresparser.DDLAction) []SQLDDLAction {
 	out := make([]SQLDDLAction, 0, len(actions))
 	for _, a := range actions {
 		out = append(out, SQLDDLAction{
-			Type:       string(a.Type),
-			ObjectName: a.ObjectName,
-			Columns:    append([]string(nil), a.Columns...),
-			Flags:      append([]string(nil), a.Flags...),
-			IndexType:  a.IndexType,
+			Type:          string(a.Type),
+			ObjectName:    a.ObjectName,
+			Schema:        a.Schema,
+			Columns:       append([]string(nil), a.Columns...),
+			ColumnDetails: convertDDLColumns(a.ColumnDetails),
+			Flags:         append([]string(nil), a.Flags...),
+			IndexType:     a.IndexType,
+		})
+	}
+	return out
+}
+
+// convertDDLColumns maps parser CREATE TABLE column metadata into analysis DTOs.
+func convertDDLColumns(cols []postgresparser.DDLColumn) []SQLDDLColumn {
+	if len(cols) == 0 {
+		return nil
+	}
+	out := make([]SQLDDLColumn, 0, len(cols))
+	for _, c := range cols {
+		out = append(out, SQLDDLColumn{
+			Name:     c.Name,
+			Type:     c.Type,
+			Nullable: c.Nullable,
+			Default:  c.Default,
 		})
 	}
 	return out

--- a/analysis/types.go
+++ b/analysis/types.go
@@ -172,13 +172,23 @@ type SQLColumnUsage struct {
 	Side       string
 }
 
+// SQLDDLColumn describes column-level metadata extracted from CREATE TABLE statements.
+type SQLDDLColumn struct {
+	Name     string
+	Type     string
+	Nullable bool
+	Default  string
+}
+
 // SQLDDLAction describes a single DDL operation in the analysis result.
 type SQLDDLAction struct {
-	Type       string
-	ObjectName string
-	Columns    []string
-	Flags      []string
-	IndexType  string
+	Type          string
+	ObjectName    string
+	Schema        string
+	Columns       []string
+	ColumnDetails []SQLDDLColumn
+	Flags         []string
+	IndexType     string
 }
 
 // SQLAnalysis is a standalone DTO representing the parsed SQL metadata.

--- a/benchmark/bench_test.go
+++ b/benchmark/bench_test.go
@@ -75,6 +75,15 @@ ORDER BY d.budget DESC`,
 )`,
 	},
 	{
+		Name: "DDL_CreateTable_Issue2",
+		SQL: `CREATE TABLE public.users (
+    id integer NOT NULL,
+    email text NOT NULL,
+    name text,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+)`,
+	},
+	{
 		Name: "ComplexUpdate",
 		SQL: `UPDATE inventory
 SET quantity = quantity - oi.qty,

--- a/doc.go
+++ b/doc.go
@@ -43,6 +43,8 @@
 //   - UPDATE with FROM clause, RETURNING
 //   - DELETE with USING clause, RETURNING
 //   - MERGE with MATCHED/NOT MATCHED actions
+//   - CREATE TABLE with column metadata (name, type, nullability, default)
+//   - CREATE/DROP INDEX, DROP TABLE, ALTER TABLE, TRUNCATE
 //   - Common Table Expressions (WITH ... AS)
 //   - Subqueries in SELECT, FROM, WHERE, and HAVING
 //   - All JOIN types (INNER, LEFT, RIGHT, FULL, CROSS, NATURAL, LATERAL)

--- a/docs/parsed-query.md
+++ b/docs/parsed-query.md
@@ -1,0 +1,126 @@
+# ParsedQuery IR Reference
+
+This document defines how to interpret `postgresparser.ParseSQL` output (`ParsedQuery` in `ir.go`).
+
+## Purpose
+
+`ParsedQuery` is an analysis-oriented intermediate representation (IR), not a full PostgreSQL AST.
+
+It is designed for:
+- query linting
+- dependency extraction
+- lineage and metadata tooling
+- migration and DDL inspection
+
+It is not designed for:
+- lossless round-trip SQL generation
+- preserving every grammar-level node detail
+
+## Scope
+
+- `ParseSQL` parses only the first statement in the input string.
+- Unrelated sections are expected to be empty for a given command.
+- `Command` is the primary discriminator for which sections to read.
+
+## Core Envelope
+
+- `Command`: High-level statement type (`SELECT`, `INSERT`, `UPDATE`, `DELETE`, `MERGE`, `DDL`, `UNKNOWN`).
+- `RawSQL`: Preprocessed SQL string used for parsing.
+- `Parameters`: Positional/anonymous parameter placeholders (`$1`, `?`, etc.).
+
+## Relation Metadata
+
+- `Tables`: Structured relation refs (`Schema`, `Name`, `Alias`, `Type`, `Raw`).
+- `CTEs`: `WITH` definitions.
+- `Subqueries`: Nested query refs discovered in the statement.
+- `JoinConditions`: Raw join condition expressions.
+- `Correlations`: Outer/inner alias correlation metadata for lateral/correlated subqueries.
+
+## Read-Query Shape
+
+- `Columns`: Projection expressions and aliases.
+- `ColumnUsage`: Expression-level column usage classification.
+- `Where`: WHERE/CURRENT clauses as raw expressions.
+- `Having`: HAVING clauses.
+- `GroupBy`: GROUP BY expressions.
+- `OrderBy`: ORDER BY expressions + direction/nulls modifiers.
+- `Limit`: LIMIT/OFFSET metadata.
+- `SetOperations`: UNION/INTERSECT/EXCEPT branches.
+- `DerivedColumns`: Alias-to-expression map for derived projection columns.
+
+## DML Shape
+
+- `InsertColumns`: Target columns for INSERT.
+- `SetClauses`: SET clauses for UPDATE (and related clause extraction).
+- `Returning`: RETURNING clauses.
+- `Upsert`: `ON CONFLICT` metadata for INSERT.
+- `Merge`: MERGE metadata (target/source/condition/actions).
+
+## DDL Shape
+
+- `DDLActions`: Normalized DDL actions extracted from DDL statements.
+
+Common DDL action fields:
+- `Type`: `CREATE_TABLE`, `DROP_TABLE`, `DROP_COLUMN`, `ALTER_TABLE`, `CREATE_INDEX`, `DROP_INDEX`, `TRUNCATE`.
+- `ObjectName`: Unqualified target object identifier.
+- `Schema`: Parsed schema when available.
+- `Columns`: Column names or indexed expressions relevant to the action.
+- `Flags`: Modifiers like `IF_EXISTS`, `IF_NOT_EXISTS`, `CASCADE`, `CONCURRENTLY`, etc.
+- `IndexType`: Index method for `CREATE_INDEX` (for example `btree`, `gin`).
+- `ColumnDetails`: Column metadata for `CREATE_TABLE` actions.
+
+`ColumnDetails` (`[]DDLColumn`) fields:
+- `Name`
+- `Type`
+- `Nullable`
+- `Default`
+
+Current DDL convention:
+- `CREATE_TABLE` populates `ColumnDetails`.
+- Other DDL actions currently do not populate `ColumnDetails`.
+- `ALTER_TABLE` uses `Columns` and `Flags` for operation-level details.
+
+## Command-to-Section Expectations
+
+- `SELECT`: read-query shape + relation metadata.
+- `INSERT`: relation metadata + DML (`InsertColumns`, `Upsert`, `Returning`).
+- `UPDATE`: relation metadata + DML (`SetClauses`, `Where`, `Returning`).
+- `DELETE`: relation metadata + DML (`Where`, `Returning`).
+- `MERGE`: relation metadata + `Merge`.
+- `DDL`: `DDLActions` (+ `Tables` where applicable).
+- `UNKNOWN`: minimal envelope only.
+
+### Compact Field Matrix
+
+| Section / Field Group | SELECT | INSERT | UPDATE | DELETE | MERGE | DDL | UNKNOWN |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Core envelope (`Command`, `RawSQL`, `Parameters`) | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| Relations (`Tables`, `CTEs`, `Subqueries`) | Yes | Yes | Yes | Yes | Yes | Sometimes | No |
+| Read-query shape (`Columns`, `Where`, `GroupBy`, `OrderBy`, `Limit`, `SetOperations`, `ColumnUsage`) | Yes | No | Partial | Partial | Partial | No | No |
+| DML shape (`InsertColumns`, `SetClauses`, `Returning`, `Upsert`) | No | Yes | Yes | Partial | No | No | No |
+| MERGE payload (`Merge`) | No | No | No | No | Yes | No | No |
+| DDL payload (`DDLActions`) | No | No | No | No | No | Yes | No |
+
+Notes:
+- "Partial" means only relevant subsets are filled for that command.
+- "Sometimes" under DDL relations means `Tables` is populated for actions where a base relation is explicitly parsed (for example `CREATE TABLE`, `ALTER TABLE`, `TRUNCATE`).
+- Empty/nil in unrelated sections is expected behavior.
+
+## Practical Guidance
+
+- Use `Command` first, then inspect relevant sections.
+- Treat empty slices/nil in unrelated sections as expected behavior.
+- For DDL identity, prefer structured values where available:
+  - use `Schema` + `ObjectName` for action identity (`ObjectName` is unqualified)
+  - use `Tables` when you need normalized relation references
+
+## Suggested Follow-up Issues
+
+1. `ALTER TABLE` delta metadata model
+   - Goal: add operation-level `AlterOps` payload instead of overloading `ColumnDetails`.
+   - Scope: `ADD COLUMN`, `DROP COLUMN`, `TYPE`, `SET/DROP DEFAULT`, `SET/DROP NOT NULL`, `RENAME COLUMN`.
+   - Non-goal: full pre/post reconstruction without schema state.
+
+2. `CREATE TABLE` type coverage expansion
+   - Goal: maintain a broad regression matrix covering common PostgreSQL type families.
+   - Scope: numerics, text/binary, time/date, JSON/XML, network, geometric, ranges, arrays.

--- a/entry.go
+++ b/entry.go
@@ -73,6 +73,11 @@ func ParseSQL(sql string) (*ParsedQuery, error) {
 		if err := populateMerge(res, mainStmt.Mergestmt(), stream); err != nil {
 			return nil, err
 		}
+	case mainStmt.Createstmt() != nil:
+		res.Command = QueryCommandDDL
+		if err := populateCreateTable(res, mainStmt.Createstmt(), stream); err != nil {
+			return nil, err
+		}
 	case mainStmt.Dropstmt() != nil:
 		res.Command = QueryCommandDDL
 		if err := populateDropStmt(res, mainStmt.Dropstmt(), stream); err != nil {

--- a/examples/ddl/main.go
+++ b/examples/ddl/main.go
@@ -1,0 +1,49 @@
+// Example: parsing CREATE, ALTER, and DELETE statements.
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/valkdb/postgresparser"
+)
+
+func main() {
+	createSQL := `CREATE TABLE public.users (
+    id integer NOT NULL,
+    email text NOT NULL,
+    name text,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);`
+	alterSQL := `ALTER TABLE public.users ADD COLUMN status text`
+	deleteSQL := `DELETE FROM public.users WHERE id = 42`
+
+	printParsed("CREATE TABLE", createSQL)
+	printParsed("ALTER TABLE", alterSQL)
+	printParsed("DELETE", deleteSQL)
+}
+
+func printParsed(label, sql string) {
+	result, err := postgresparser.ParseSQL(sql)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("=== %s ===\n", label)
+	fmt.Printf("SQL: %s\n", sql)
+	fmt.Printf("Command: %s\n", result.Command)
+	for _, action := range result.DDLActions {
+		if action.Schema != "" {
+			fmt.Printf("Action: %s %s.%s\n", action.Type, action.Schema, action.ObjectName)
+		} else {
+			fmt.Printf("Action: %s %s\n", action.Type, action.ObjectName)
+		}
+		for _, col := range action.ColumnDetails {
+			fmt.Printf("  - %s %s nullable=%t default=%q\n", col.Name, col.Type, col.Nullable, col.Default)
+		}
+	}
+	if len(result.Where) > 0 {
+		fmt.Printf("Where: %v\n", result.Where)
+	}
+	fmt.Println()
+}

--- a/ir.go
+++ b/ir.go
@@ -102,6 +102,7 @@ type MergeClause struct {
 type DDLActionType string
 
 const (
+	DDLCreateTable DDLActionType = "CREATE_TABLE"
 	DDLDropTable   DDLActionType = "DROP_TABLE"
 	DDLDropColumn  DDLActionType = "DROP_COLUMN"
 	DDLAlterTable  DDLActionType = "ALTER_TABLE"
@@ -110,13 +111,23 @@ const (
 	DDLTruncate    DDLActionType = "TRUNCATE"
 )
 
+// DDLColumn describes column-level metadata extracted from CREATE TABLE statements.
+type DDLColumn struct {
+	Name     string
+	Type     string
+	Nullable bool
+	Default  string
+}
+
 // DDLAction describes a single DDL operation extracted from a statement.
 type DDLAction struct {
-	Type       DDLActionType
-	ObjectName string   // Table or index name
-	Columns    []string // Affected columns
-	Flags      []string // IF_EXISTS, CONCURRENTLY, CASCADE, etc.
-	IndexType  string   // btree, gin, gist, hash (CREATE INDEX only)
+	Type          DDLActionType
+	ObjectName    string      // Unqualified table/index/object name
+	Schema        string      // Optional schema qualifier
+	Columns       []string    // Affected columns
+	ColumnDetails []DDLColumn // Column metadata (CREATE TABLE)
+	Flags         []string    // IF_EXISTS, CONCURRENTLY, CASCADE, etc.
+	IndexType     string      // btree, gin, gist, hash (CREATE INDEX only)
 }
 
 // SubqueryRef records metadata for subqueries discovered in FROM or set operations.

--- a/parser_ir_select_test.go
+++ b/parser_ir_select_test.go
@@ -362,9 +362,9 @@ LEFT JOIN purchases p ON u.id = p.user_id AND p.amount > 0`
 	assert.Contains(t, ir.JoinConditions[0], "p.amount > 0", "unexpected join condition")
 }
 
-// TestIR_FallbackToUnknown confirms unsupported statements return UNKNOWN.
+// TestIR_FallbackToUnknown confirms unsupported statements still return UNKNOWN.
 func TestIR_FallbackToUnknown(t *testing.T) {
-	sql := `CREATE TABLE demo(id INT PRIMARY KEY);`
+	sql := `BEGIN`
 	ir := parseAssertNoError(t, sql)
 
 	assert.Equal(t, QueryCommandUnknown, ir.Command, "expected UNKNOWN command for unsupported statement")


### PR DESCRIPTION
Release Description

This release completes CREATE TABLE metadata extraction for Issue #2 and also fixes a DDL identity inconsistency discovered during review.

What was added:
- CREATE TABLE extraction now includes table/schema plus per-column metadata:
  - name
  - type
  - nullable
  - default
- Coverage added for a broad PostgreSQL type matrix.
- Docs and example usage were added/expanded.

Inconsistency found and fixed:
- We found that DDL actions were inconsistent when schema-qualified names were present:
  - CREATE TABLE used unqualified `ObjectName` + `Schema`.
  - Other DDL actions sometimes kept fully-qualified values in `ObjectName` while also setting `Schema`.
- This caused duplicated schema rendering in downstream tools (for example `public.public.users`).

Fix applied:
- Standardized DDL identity across DDL actions:
  - `ObjectName` is now unqualified.
  - `Schema` carries the schema qualifier.
- Applied to DROP TABLE, DROP INDEX, ALTER TABLE, CREATE INDEX, and TRUNCATE.
- Updated docs/tests/examples accordingly.

Validation:
- `go test ./...` passes.
- DDL benchmark sanity run passes.