### PR TITLE
docs: add architecture decision guide and GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,74 @@
+name: Bug Report
+description: Report incorrect parsing, missing data, or unexpected errors
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug! A minimal SQL example helps us fix it fast.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What happened? What did you expect instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: sql-input
+    attributes:
+      label: SQL input
+      description: The SQL statement that triggers the bug. Minimal repro preferred.
+      render: sql
+      placeholder: "SELECT * FROM users WHERE id = $1"
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual-output
+    attributes:
+      label: Actual output
+      description: What did `ParseSQL` or `AnalyzeSQL` return? Include the relevant struct fields or error message.
+      render: go
+      placeholder: |
+        // e.g.
+        result.Command  // "UNKNOWN" (expected "SELECT")
+        result.Tables   // [] (expected [{Name: "users"}])
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-output
+    attributes:
+      label: Expected output
+      description: What should the parser have returned?
+      render: go
+    validations:
+      required: false
+
+  - type: input
+    id: version
+    attributes:
+      label: postgresparser version
+      description: "Output of `go list -m github.com/valkdb/postgresparser`"
+      placeholder: "v1.1.0"
+    validations:
+      required: false
+
+  - type: input
+    id: pg-version
+    attributes:
+      label: PostgreSQL version (if relevant)
+      description: The PostgreSQL version the SQL targets
+      placeholder: "16.2"
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Go version, OS, related issues, workarounds tried.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Architecture Decision Guide
+    url: https://github.com/ValkDB/postgresparser/blob/main/docs/architecture-decision-guide.md
+    about: Not sure if your feature belongs in the core parser or analysis layer? Check here first.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,80 @@
+name: Feature Request
+description: Request new SQL parsing or analysis capabilities
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement to postgresparser!
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What capability are you looking for?
+      placeholder: "e.g., Parse CREATE TABLE to extract column metadata"
+    validations:
+      required: true
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use case
+      description: What are you building? How would this feature help?
+      placeholder: "e.g., I'm generating documentation from pg_dump output and need structured column info"
+    validations:
+      required: true
+
+  - type: textarea
+    id: sql-example
+    attributes:
+      label: SQL example
+      description: Provide a representative SQL statement you need to parse.
+      render: sql
+      placeholder: |
+        CREATE TABLE public.users (
+            id integer NOT NULL,
+            email text NOT NULL,
+            name text
+        );
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-output
+    attributes:
+      label: Expected output
+      description: What structured data should the parser return? Pseudocode, JSON, or Go struct literals are all fine.
+      render: json
+      placeholder: |
+        {
+          "command": "DDL",
+          "tables": [{"schema": "public", "name": "users"}],
+          "ddl_actions": [{
+            "type": "CREATE_TABLE",
+            "columns": ["id", "email", "name"]
+          }]
+        }
+    validations:
+      required: false
+
+  - type: dropdown
+    id: layer
+    attributes:
+      label: Which layer?
+      description: |
+        Where should this feature live? See [Architecture Decision Guide](https://github.com/ValkDB/postgresparser/blob/main/docs/architecture-decision-guide.md) if unsure.
+      options:
+        - "Core parser (new IR field / parse tree extraction)"
+        - "Analysis layer (interpretation / schema-aware / convenience)"
+        - "Not sure"
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Anything else? Related issues, PostgreSQL version specifics, alternative approaches you considered.
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,40 @@
+## Summary
+
+<!-- 1-3 bullet points describing what this PR does -->
+
+## Layer
+
+<!-- Which layer does this change touch? Check all that apply. -->
+
+- [ ] Core parser (`ir.go`, `ddl.go`, `select.go`, `dml_*.go`, `merge.go`, `setops.go`, `entry.go`)
+- [ ] Analysis layer (`analysis/`)
+- [ ] Docs / examples
+- [ ] CI / tooling
+
+## SQL examples
+
+<!-- Show at least one SQL statement this PR affects, with before/after output if applicable. -->
+
+```sql
+-- example
+```
+
+## Test plan
+
+<!-- How was this tested? Check all that apply. -->
+
+- [ ] New unit tests added
+- [ ] Existing tests updated
+- [ ] `make test` passes (race detector + coverage)
+- [ ] `make vet` passes
+- [ ] Manual verification with `examples/`
+
+## Related issues
+
+<!-- Link related issues: Fixes #123, Part of #456 -->
+
+## Checklist
+
+- [ ] No changes to `gen/` (auto-generated ANTLR code)
+- [ ] New IR fields documented in `docs/parsed-query.md` (if applicable)
+- [ ] Public API additions are backward compatible

--- a/docs/architecture-decision-guide.md
+++ b/docs/architecture-decision-guide.md
@@ -1,0 +1,61 @@
+# Architecture Decision Guide: Core Parser vs Analysis Layer
+
+Where does a new feature belong? Use this guide when deciding.
+
+- **Core parser** (`postgresparser` root) — SQL text in, `ParsedQuery` IR out. Walks ANTLR parse tree nodes. No external inputs.
+  Key files: `entry.go`, `ir.go`, `select.go`, `dml_*.go`, `ddl.go`, `merge.go`, `setops.go`
+
+- **Analysis layer** (`analysis/`) — operates on `*ParsedQuery` + optional external metadata (`ColumnSchema`). Interprets, composes, enriches.
+  Key files: `analysis/analysis.go`, `analysis/types.go`, `analysis/where_conditions.go`, `analysis/join_parser.go`, `analysis/combined_extractor.go`, `analysis/helpers.go`
+
+## Decision Flowchart
+
+```
+New feature or enhancement
+|
++- Does it require external inputs beyond SQL text?
+|  (schema metadata, PK info, config, runtime state)
+|  YES -> analysis/
+|
++- Does it parse/interpret raw string fields from the IR?
+|  (extracting operators from WHERE strings, splitting JOIN conditions)
+|  YES -> analysis/
+|
++- Does it walk ANTLR parse tree nodes (gen.*Context)?
+|  YES -> core parser (ddl.go, select.go, dml_*.go, or new file)
+|
++- Is it a new IR field that the grammar directly provides?
+|  YES -> core parser (ir.go for type, visitor file for extraction)
+|
++- Is it a convenience/utility over existing IR fields?
+|  YES -> analysis/helpers.go
+|
++- None of the above?
+   -> Discuss. It's probably analysis/, but worth reviewing.
+```
+
+## Examples
+
+### Core parser:
+
+| Feature | Why |
+|---|---|
+| Extract RETURNING clause columns | Direct parse tree extraction |
+| Parse window function PARTITION BY | Grammar-level clause, walks `gen.*Context` |
+| Add `CONCURRENTLY` flag to DDL | Direct flag from parse tree node |
+| Support MERGE statement | New statement type, needs new visitor file |
+
+### Analysis:
+
+| Feature | Why |
+|---|---|
+| Structured WHERE conditions (operator, value, table) | Interprets raw IR strings |
+| FK relationship detection from JOINs | Requires schema metadata (`IsPrimaryKey`) |
+| Query complexity scoring | Derived metric from IR fields |
+| Missing-WHERE-on-DELETE detection | Semantic rule, not grammar extraction |
+| Schema validation (do referenced columns exist?) | Requires external schema metadata |
+| `BaseTables()` | Convenience function over IR/DTO |
+
+## Why WithSchema Methods Stay in Analysis
+
+`ExtractJoinRelationshipsWithSchema` and `ExtractQueryAnalysisWithSchema` accept `map[string][]ColumnSchema` — external metadata the grammar cannot provide. The core parser's contract is "SQL text in, IR out" with no side inputs. These functions require DB metadata, perform semantic inference, and return types with no grammar-level equivalent.


### PR DESCRIPTION

  ## Summary

  - Add architecture decision guide defining the boundary between core parser and analysis layer
  - Add GitHub issue templates (feature request, bug report) with structured forms
  - Add PR template with layer checklist and test plan

  ## Files

  - `docs/architecture-decision-guide.md` — flowchart + examples for "where does this feature go?"
  - `.github/ISSUE_TEMPLATE/feature_request.yml` — structured form with SQL example, use case, expected output, layer dropdown
  - `.github/ISSUE_TEMPLATE/bug_report.yml` — structured form with SQL input, actual/expected output, version
  - `.github/ISSUE_TEMPLATE/config.yml` — template chooser with link to architecture guide
  - `.github/pull_request_template.md` — layer checklist, SQL examples, test plan, `gen/` guard