### PR TITLE
Fix `LICENSE` text to allow pkg.go.dev to recognize it

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,4 @@
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -48,7 +49,7 @@
       "Contribution" shall mean any work of authorship, including
       the original version of the Work and any modifications or additions
       to that Work or Derivative Works thereof, that is intentionally
-      submitted to the Licensor for inclusion in the Work by the copyright owner
+      submitted to Licensor for inclusion in the Work by the copyright owner
       or by an individual or Legal Entity authorized to submit on behalf of
       the copyright owner. For the purposes of this definition, "submitted"
       means any form of electronic, verbal, or written communication sent
@@ -60,7 +61,7 @@
       designated in writing by the copyright owner as "Not a Contribution."
 
       "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by the Licensor and
+      on behalf of whom a Contribution has been received by Licensor and
       subsequently incorporated within the Work.
 
    2. Grant of Copyright License. Subject to the terms and conditions of
@@ -106,7 +107,7 @@
       (d) If the Work includes a "NOTICE" text file as part of its
           distribution, then any Derivative Works that You distribute must
           include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding any notices that do not
+          within such NOTICE file, excluding those notices that do not
           pertain to any part of the Derivative Works, in at least one
           of the following places: within a NOTICE text file distributed
           as part of the Derivative Works; within the Source form or


### PR DESCRIPTION
This PR fixes the LICENSE file to actually contain the Apache 2.0 text, as provided by the [source of truth](https://www.apache.org/licenses/LICENSE-2.0.txt). For some reason, there are three changed articles and pronouns at HEAD, which impedes verification by tooling. I have verified this works correctly by running `pkgsite` locally.

On `pkg.go.dev`:

<img width="653" height="81" alt="Screenshot 2026-02-11 at 2 15 32 PM" src="https://github.com/user-attachments/assets/c87f7b34-a265-47a3-a33a-c7618039e0c9" />

Locally with `pkgsite`:

<img width="653" height="81" alt="Screenshot 2026-02-11 at 2 15 51 PM" src="https://github.com/user-attachments/assets/345f6a6b-34d4-4a7e-a2e3-234e20ca122b" />

It is not clear why this diff exists, but generally fixing what appear to be grammatical mistakes in legal texts such as licenses is not a good idea.