### PR TITLE
Added support for reading comments, and table comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ go get github.com/valkdb/postgresparser
 Handles the SQL you actually write in production:
 
 - **DML**: SELECT, INSERT, UPDATE, DELETE, MERGE
-- **DDL**: CREATE TABLE (columns/type/nullability/default), CREATE INDEX, DROP TABLE/INDEX, ALTER TABLE, TRUNCATE
+- **DDL**: CREATE TABLE (columns/type/nullability/default), CREATE INDEX, DROP TABLE/INDEX, ALTER TABLE, TRUNCATE, COMMENT ON
 - **CTEs**: `WITH ... AS` including `RECURSIVE`, materialization hints
 - **JOINs**: INNER, LEFT, RIGHT, FULL, CROSS, NATURAL, LATERAL
 - **Subqueries**: in SELECT, FROM, WHERE, and HAVING
@@ -84,6 +84,7 @@ Handles the SQL you actually write in production:
 - **Parameters**: `$1`, `$2`, ...
 
 IR field reference: [ParsedQuery IR Reference](docs/parsed-query.md)
+Comment extraction guide: [Comment Extraction Guide](docs/comments.md)
 
 ## Statement Count Handling
 
@@ -95,6 +96,9 @@ Use the API variant that matches your input contract:
   - Correlation is deterministic: `Statements[i].Index` maps to source statement order.
   - `HasFailures` is `true` when any statement has a nil `Query` or any `Warnings`.
 - `ParseSQLStrict(sql)` requires exactly one statement and returns `ErrMultipleStatements` when input contains more than one.
+- `ParseSQLWithOptions(sql, opts)`, `ParseSQLAllWithOptions(sql, opts)`, and `ParseSQLStrictWithOptions(sql, opts)` expose optional extraction flags.
+  - `IncludeCreateTableFieldComments` enables inline `--` field-comment extraction in `CREATE TABLE`.
+  - `COMMENT ON` extraction is always enabled.
 
 ## Supported SQL Statements
 
@@ -103,7 +107,7 @@ See [docs/supported-statements.md](./docs/supported-statements.md) for full deta
 | Category | Statements | Status |
 |----------|-----------|--------|
 | **DML** | SELECT, INSERT, UPDATE, DELETE, MERGE | Full IR extraction |
-| **DDL** | CREATE TABLE, ALTER TABLE, DROP TABLE/INDEX, CREATE INDEX, TRUNCATE | Full IR extraction |
+| **DDL** | CREATE TABLE, ALTER TABLE, DROP TABLE/INDEX, CREATE INDEX, TRUNCATE, COMMENT ON | Full IR extraction |
 | **Utility** | SET, SHOW, RESET | Graceful — returns `UNKNOWN`, no error |
 | **Other** | GRANT, REVOKE, CREATE VIEW/FUNCTION/TRIGGER, COPY, EXPLAIN, VACUUM, BEGIN/COMMIT/ROLLBACK, etc. | Not yet supported — may error or return `UNKNOWN` |
 

--- a/analysis/types.go
+++ b/analysis/types.go
@@ -178,17 +178,21 @@ type SQLDDLColumn struct {
 	Type     string
 	Nullable bool
 	Default  string
+	Comment  []string
 }
 
 // SQLDDLAction describes a single DDL operation in the analysis result.
 type SQLDDLAction struct {
 	Type          string
 	ObjectName    string
+	ObjectType    string
 	Schema        string
 	Columns       []string
 	ColumnDetails []SQLDDLColumn
 	Flags         []string
 	IndexType     string
+	Target        string
+	Comment       string
 }
 
 // SQLParseWarningCode identifies non-fatal parser notices in analysis batch results.

--- a/ddl_comment.go
+++ b/ddl_comment.go
@@ -1,0 +1,577 @@
+package postgresparser
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+
+	"github.com/antlr4-go/antlr/v4"
+
+	"github.com/valkdb/postgresparser/gen"
+)
+
+// populateCommentStmt handles COMMENT ON metadata extraction.
+func populateCommentStmt(result *ParsedQuery, ctx gen.ICommentstmtContext, tokens antlr.TokenStream) error {
+	if ctx == nil {
+		return fmt.Errorf("comment statement: %w", ErrNilContext)
+	}
+
+	action := DDLAction{
+		Type:    DDLComment,
+		Comment: decodeCommentText(ctx.Comment_text(), tokens),
+	}
+
+	switch {
+	case ctx.COLUMN() != nil && ctx.Any_name() != nil:
+		action.ObjectType = "COLUMN"
+		rawName := contextText(tokens, ctx.Any_name())
+		action.Target = rawName
+		schema, tableName, columnName := splitQualifiedColumnName(rawName)
+		action.Schema = schema
+		action.ObjectName = tableName
+		if columnName != "" {
+			action.Columns = []string{columnName}
+		}
+		if tableName != "" {
+			tableRaw := tableName
+			if schema != "" {
+				tableRaw = schema + "." + tableName
+			}
+			result.Tables = append(result.Tables, TableRef{
+				Schema: schema,
+				Name:   tableName,
+				Type:   TableTypeBase,
+				Raw:    tableRaw,
+			})
+		}
+
+	case ctx.Object_type_any_name() != nil && ctx.Any_name() != nil:
+		action.ObjectType = strings.ToUpper(normalizeSpace(contextText(tokens, ctx.Object_type_any_name())))
+		rawName := contextText(tokens, ctx.Any_name())
+		action.Target = rawName
+		schema, objectName := splitQualifiedName(rawName)
+		action.Schema = schema
+		action.ObjectName = objectName
+		if action.ObjectType == "TABLE" || action.ObjectType == "FOREIGN TABLE" {
+			result.Tables = append(result.Tables, TableRef{
+				Schema: schema,
+				Name:   objectName,
+				Type:   TableTypeBase,
+				Raw:    rawName,
+			})
+		}
+
+	case ctx.Object_type_name() != nil && ctx.Name() != nil:
+		action.ObjectType = strings.ToUpper(normalizeSpace(contextText(tokens, ctx.Object_type_name())))
+		rawName := contextText(tokens, ctx.Name())
+		action.Target = rawName
+		schema, objectName := splitQualifiedName(rawName)
+		action.Schema = schema
+		action.ObjectName = objectName
+
+	case ctx.TYPE_P() != nil && len(ctx.AllTypename()) > 0:
+		action.ObjectType = "TYPE"
+		rawName := contextText(tokens, ctx.AllTypename()[0])
+		action.Target = rawName
+		schema, objectName := splitQualifiedName(rawName)
+		action.Schema = schema
+		action.ObjectName = objectName
+
+	case ctx.DOMAIN_P() != nil && len(ctx.AllTypename()) > 0:
+		action.ObjectType = "DOMAIN"
+		rawName := contextText(tokens, ctx.AllTypename()[0])
+		action.Target = rawName
+		schema, objectName := splitQualifiedName(rawName)
+		action.Schema = schema
+		action.ObjectName = objectName
+
+	default:
+		action.ObjectType = "UNKNOWN"
+	}
+
+	result.DDLActions = append(result.DDLActions, action)
+	return nil
+}
+
+func decodeCommentText(commentCtx gen.IComment_textContext, tokens antlr.TokenStream) string {
+	if commentCtx == nil {
+		return ""
+	}
+	raw := contextText(tokens, commentCtx)
+	if raw == "" || strings.EqualFold(raw, "NULL") {
+		return ""
+	}
+	return decodeCommentStringLiteral(raw)
+}
+
+func decodeCommentStringLiteral(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return ""
+	}
+	if strings.HasPrefix(trimmed, "$") {
+		if decoded, ok := decodeDollarQuotedString(trimmed); ok {
+			return decoded
+		}
+	}
+
+	upper := strings.ToUpper(trimmed)
+	switch {
+	case strings.HasPrefix(upper, "E'") || strings.HasPrefix(upper, "N'"):
+		decoded, ok := decodeSingleQuoted(trimmed[1:])
+		if !ok {
+			return trimmed
+		}
+		return decodeEscapedString(decoded)
+	case strings.HasPrefix(upper, "U&'"):
+		decoded, ok := decodeSingleQuoted(trimmed[2:])
+		if !ok {
+			return trimmed
+		}
+		return decoded
+	}
+
+	if decoded, ok := decodeSingleQuoted(trimmed); ok {
+		return decoded
+	}
+	return trimmed
+}
+
+func decodeSingleQuoted(raw string) (string, bool) {
+	if len(raw) < 2 || raw[0] != '\'' || raw[len(raw)-1] != '\'' {
+		return "", false
+	}
+	inner := raw[1 : len(raw)-1]
+	return strings.ReplaceAll(inner, "''", "'"), true
+}
+
+// escapedStringReplacer handles common C-style escape sequences in PostgreSQL
+// E'...' string literals. Allocated once to avoid per-call allocations.
+var escapedStringReplacer = strings.NewReplacer(
+	`\\`, `\`,
+	`\'`, `'`,
+	`\n`, "\n",
+	`\r`, "\r",
+	`\t`, "\t",
+	`\b`, "\b",
+	`\f`, "\f",
+)
+
+func decodeEscapedString(raw string) string {
+	return escapedStringReplacer.Replace(raw)
+}
+
+func decodeDollarQuotedString(raw string) (string, bool) {
+	if raw == "" || raw[0] != '$' {
+		return "", false
+	}
+	secondDollar := strings.IndexByte(raw[1:], '$')
+	if secondDollar < 0 {
+		return "", false
+	}
+	delimEnd := secondDollar + 1
+	delim := raw[:delimEnd+1]
+	if len(raw) < len(delim)*2 || !strings.HasSuffix(raw, delim) {
+		return "", false
+	}
+	return raw[len(delim) : len(raw)-len(delim)], true
+}
+
+func splitQualifiedColumnName(name string) (schema, table, column string) {
+	parts := splitQuotedDot(strings.TrimSpace(name))
+	if len(parts) == 0 {
+		return "", "", ""
+	}
+	column = strings.TrimSpace(parts[len(parts)-1])
+	if len(parts) == 1 {
+		return "", "", column
+	}
+	table = strings.TrimSpace(parts[len(parts)-2])
+	if len(parts) == 2 {
+		return "", table, column
+	}
+	schema = strings.TrimSpace(strings.Join(parts[:len(parts)-2], "."))
+	return schema, table, column
+}
+
+func contextText(tokens antlr.TokenStream, ctx antlr.RuleContext) string {
+	return strings.TrimSpace(ctxText(tokens, ctx))
+}
+
+type createTableElementComments struct {
+	element  string
+	comments []string
+}
+
+type createTableElementSplitter struct {
+	runes []rune
+
+	elements        []createTableElementComments
+	current         strings.Builder
+	pendingComments []string
+	depth           int
+	inSingle        bool
+	inDouble        bool
+	inDollar        bool
+	dollarTag       string
+	inBlockComment  bool
+	hasContent      bool
+}
+
+// extractCreateTableFieldCommentsByColumn maps CREATE TABLE column names to
+// line comments (`-- ...`) that immediately precede each column definition.
+func extractCreateTableFieldCommentsByColumn(createStmtSQL string) map[string][]string {
+	body := extractCreateTableBody(createStmtSQL)
+	if body == "" {
+		return nil
+	}
+
+	elements := splitCreateTableElementsWithComments(body)
+	if len(elements) == 0 {
+		return nil
+	}
+
+	commentsByColumn := make(map[string][]string)
+	for _, elem := range elements {
+		if len(elem.comments) == 0 {
+			continue
+		}
+		colName := extractCreateTableColumnNameFromElement(elem.element)
+		if colName == "" {
+			continue
+		}
+		normalizedCol := normalizeCreateTableColumnName(colName)
+		if normalizedCol == "" {
+			continue
+		}
+		lines := make([]string, 0, len(elem.comments))
+		for _, line := range elem.comments {
+			trimmed := strings.TrimSpace(line)
+			if trimmed != "" {
+				lines = append(lines, trimmed)
+			}
+		}
+		if len(lines) > 0 {
+			commentsByColumn[normalizedCol] = lines
+		}
+	}
+
+	if len(commentsByColumn) == 0 {
+		return nil
+	}
+	return commentsByColumn
+}
+
+// extractCreateTableBody returns the SQL text inside the first top-level
+// parentheses pair of the CREATE TABLE statement.
+func extractCreateTableBody(sql string) string {
+	runes := []rune(sql)
+	if len(runes) == 0 {
+		return ""
+	}
+
+	openIdx := -1
+	depth := 0
+	inSingle := false
+	inDouble := false
+	inDollar := false
+	dollarTag := ""
+	inLineComment := false
+	inBlockComment := false
+
+	for i := 0; i < len(runes); i++ {
+		r := runes[i]
+
+		if inLineComment {
+			if r == '\n' || r == '\r' {
+				inLineComment = false
+			}
+			continue
+		}
+		if inBlockComment {
+			if r == '*' && i+1 < len(runes) && runes[i+1] == '/' {
+				inBlockComment = false
+				i++
+			}
+			continue
+		}
+		if inDollar {
+			if r == '$' && hasDollarTerminator(runes, i, dollarTag) {
+				i += len([]rune(dollarTag)) + 1
+				inDollar = false
+				dollarTag = ""
+			}
+			continue
+		}
+		if inSingle {
+			if r == '\'' {
+				if i+1 < len(runes) && runes[i+1] == '\'' {
+					i++
+				} else {
+					inSingle = false
+				}
+			}
+			continue
+		}
+		if inDouble {
+			if r == '"' {
+				if i+1 < len(runes) && runes[i+1] == '"' {
+					i++
+				} else {
+					inDouble = false
+				}
+			}
+			continue
+		}
+
+		if r == '-' && i+1 < len(runes) && runes[i+1] == '-' {
+			inLineComment = true
+			i++
+			continue
+		}
+		if r == '/' && i+1 < len(runes) && runes[i+1] == '*' {
+			inBlockComment = true
+			i++
+			continue
+		}
+		if r == '\'' {
+			inSingle = true
+			continue
+		}
+		if r == '"' {
+			inDouble = true
+			continue
+		}
+		if r == '$' {
+			if tag, ok := parseDollarTag(runes, i); ok {
+				inDollar = true
+				dollarTag = tag
+				i += len([]rune(tag)) + 1
+				continue
+			}
+		}
+
+		switch r {
+		case '(':
+			if openIdx < 0 {
+				openIdx = i
+				depth = 1
+				continue
+			}
+			if depth > 0 {
+				depth++
+			}
+		case ')':
+			if depth > 0 {
+				depth--
+				if depth == 0 && openIdx >= 0 {
+					return string(runes[openIdx+1 : i])
+				}
+			}
+		}
+	}
+
+	return ""
+}
+
+// splitCreateTableElementsWithComments splits CREATE TABLE body elements by
+// top-level commas while keeping preceding line comments for each element.
+func splitCreateTableElementsWithComments(body string) []createTableElementComments {
+	splitter := createTableElementSplitter{
+		runes: []rune(body),
+	}
+	if len(splitter.runes) == 0 {
+		return nil
+	}
+
+	for i := 0; i < len(splitter.runes); i++ {
+		r := splitter.runes[i]
+
+		if splitter.inBlockComment {
+			if r == '*' && i+1 < len(splitter.runes) && splitter.runes[i+1] == '/' {
+				splitter.inBlockComment = false
+				i++
+			}
+			continue
+		}
+		if splitter.inDollar {
+			splitter.current.WriteRune(r)
+			if r == '$' && hasDollarTerminator(splitter.runes, i, splitter.dollarTag) {
+				tagLen := len([]rune(splitter.dollarTag))
+				for j := 1; j < tagLen+2 && i+j < len(splitter.runes); j++ {
+					splitter.current.WriteRune(splitter.runes[i+j])
+				}
+				i += tagLen + 1
+				splitter.inDollar = false
+				splitter.dollarTag = ""
+			}
+			continue
+		}
+		if splitter.inSingle {
+			splitter.current.WriteRune(r)
+			if r == '\'' {
+				if i+1 < len(splitter.runes) && splitter.runes[i+1] == '\'' {
+					i++
+					splitter.current.WriteRune(splitter.runes[i])
+				} else {
+					splitter.inSingle = false
+				}
+			}
+			continue
+		}
+		if splitter.inDouble {
+			splitter.current.WriteRune(r)
+			if r == '"' {
+				if i+1 < len(splitter.runes) && splitter.runes[i+1] == '"' {
+					i++
+					splitter.current.WriteRune(splitter.runes[i])
+				} else {
+					splitter.inDouble = false
+				}
+			}
+			continue
+		}
+
+		if r == '-' && i+1 < len(splitter.runes) && splitter.runes[i+1] == '-' {
+			commentStart := i + 2
+			commentEnd := commentStart
+			for commentEnd < len(splitter.runes) && splitter.runes[commentEnd] != '\n' && splitter.runes[commentEnd] != '\r' {
+				commentEnd++
+			}
+			if !splitter.hasContent {
+				commentLine := strings.TrimSpace(string(splitter.runes[commentStart:commentEnd]))
+				if commentLine != "" {
+					splitter.pendingComments = append(splitter.pendingComments, commentLine)
+				}
+			}
+			i = commentEnd - 1
+			continue
+		}
+		if r == '/' && i+1 < len(splitter.runes) && splitter.runes[i+1] == '*' {
+			splitter.inBlockComment = true
+			i++
+			continue
+		}
+		if r == '\'' {
+			splitter.inSingle = true
+			splitter.current.WriteRune(r)
+			splitter.hasContent = true
+			continue
+		}
+		if r == '"' {
+			splitter.inDouble = true
+			splitter.current.WriteRune(r)
+			splitter.hasContent = true
+			continue
+		}
+		if r == '$' {
+			if tag, ok := parseDollarTag(splitter.runes, i); ok {
+				splitter.inDollar = true
+				splitter.dollarTag = tag
+				terminatorLen := len([]rune(tag)) + 2
+				for j := 0; j < terminatorLen && i+j < len(splitter.runes); j++ {
+					splitter.current.WriteRune(splitter.runes[i+j])
+				}
+				i += terminatorLen - 1
+				splitter.hasContent = true
+				continue
+			}
+		}
+
+		if r == ',' && splitter.depth == 0 {
+			splitter.flushCurrent()
+			continue
+		}
+		if r == '(' {
+			splitter.depth++
+		} else if r == ')' && splitter.depth > 0 {
+			splitter.depth--
+		}
+
+		splitter.current.WriteRune(r)
+		if !unicode.IsSpace(r) {
+			splitter.hasContent = true
+		}
+	}
+
+	splitter.flushCurrent()
+	if len(splitter.elements) == 0 {
+		return nil
+	}
+	return splitter.elements
+}
+
+func (s *createTableElementSplitter) flushCurrent() {
+	elem := strings.TrimSpace(s.current.String())
+	if elem == "" {
+		s.current.Reset()
+		s.pendingComments = nil
+		s.hasContent = false
+		return
+	}
+	item := createTableElementComments{
+		element: elem,
+	}
+	if len(s.pendingComments) > 0 {
+		item.comments = append([]string(nil), s.pendingComments...)
+	}
+	s.elements = append(s.elements, item)
+	s.current.Reset()
+	s.pendingComments = nil
+	s.hasContent = false
+}
+
+func extractCreateTableColumnNameFromElement(element string) string {
+	trimmed := strings.TrimSpace(element)
+	if trimmed == "" {
+		return ""
+	}
+	token := readLeadingIdentifierToken(trimmed)
+	if token == "" {
+		return ""
+	}
+	if isCreateTableConstraintToken(token) {
+		return ""
+	}
+	return token
+}
+
+func readLeadingIdentifierToken(s string) string {
+	runes := []rune(strings.TrimSpace(s))
+	if len(runes) == 0 {
+		return ""
+	}
+
+	if runes[0] == '"' {
+		for i := 1; i < len(runes); i++ {
+			if runes[i] != '"' {
+				continue
+			}
+			if i+1 < len(runes) && runes[i+1] == '"' {
+				i++
+				continue
+			}
+			return string(runes[:i+1])
+		}
+		return ""
+	}
+
+	for i, r := range runes {
+		if unicode.IsSpace(r) || r == ',' || r == '(' || r == ')' {
+			if i == 0 {
+				return ""
+			}
+			return string(runes[:i])
+		}
+	}
+	return string(runes)
+}
+
+func isCreateTableConstraintToken(token string) bool {
+	switch strings.ToUpper(trimIdentQuotes(strings.TrimSpace(token))) {
+	case "CONSTRAINT", "PRIMARY", "UNIQUE", "FOREIGN", "CHECK", "EXCLUDE", "LIKE":
+		return true
+	default:
+		return false
+	}
+}

--- a/doc.go
+++ b/doc.go
@@ -22,6 +22,11 @@
 // per-statement status/warnings, or ParseSQLStrict to fail unless exactly one
 // statement is present.
 //
+// Options-enabled variants are also available:
+//   - ParseSQLWithOptions
+//   - ParseSQLAllWithOptions
+//   - ParseSQLStrictWithOptions
+//
 // # Analysis Subpackage
 //
 // The analysis subpackage provides higher-level SQL analysis on top of the
@@ -49,6 +54,7 @@
 //   - DELETE with USING clause, RETURNING
 //   - MERGE with MATCHED/NOT MATCHED actions
 //   - CREATE TABLE with column metadata (name, type, nullability, default)
+//   - COMMENT ON statements (TABLE/COLUMN/INDEX targets)
 //   - CREATE/DROP INDEX, DROP TABLE, ALTER TABLE, TRUNCATE
 //   - Common Table Expressions (WITH ... AS)
 //   - Subqueries in SELECT, FROM, WHERE, and HAVING

--- a/docs/comments.md
+++ b/docs/comments.md
@@ -1,0 +1,169 @@
+# Comment Extraction Guide
+
+This guide covers:
+
+- `COMMENT ON ...` statement extraction (always enabled)
+- inline `--` field comment extraction in `CREATE TABLE` (option-controlled)
+
+## COMMENT ON (Always Enabled)
+
+`COMMENT ON` statements are parsed as DDL actions with:
+
+- `Type = "COMMENT"`
+- `ObjectType` (for example `TABLE`, `COLUMN`, `INDEX`)
+- `ObjectName`
+- `Schema` (when available)
+- `Target` (generic path form, for example `public.users.email`)
+- `Comment`
+
+### Example: table comment
+
+```sql
+COMMENT ON TABLE public.users IS 'Stores user account information';
+```
+
+### Example: column comment
+
+```sql
+COMMENT ON COLUMN public.users.email IS 'User email address, must be unique';
+```
+
+For column comments:
+
+- `ObjectName` is the table name (`users`)
+- `Columns` contains the target column (`["email"]`)
+
+### Identifier Notes (`Target`, dots, quoting)
+
+- `Target` preserves the SQL path text (for example `public.users.email`).
+- Structured fields (`Schema`, `ObjectName`, `Columns`) are extracted with quote-aware splitting.
+- Identifiers that contain `.` must be quoted in PostgreSQL SQL text (for example `public."my.table"."my.col"`).
+- Unquoted dots are always treated as separators. For example, `public.my.table.my.col` is interpreted as a qualified path, not as identifier names containing dots.
+
+Current behavior examples:
+- `COMMENT ON COLUMN public."my.table"."my.col" IS 'x';`
+  maps to `Schema=public`, `ObjectName="my.table"`, `Columns=["my.col"]`, `Target=public."my.table"."my.col"`.
+- `COMMENT ON COLUMN public.my.table.my.col IS 'x';`
+  maps to `Schema=public.my.table`, `ObjectName=my`, `Columns=["col"]`, `Target=public.my.table.my.col`.
+
+### Example: index comment
+
+```sql
+COMMENT ON INDEX public.idx_bookings_dates IS 'Composite index for efficient date range queries on bookings';
+```
+
+### Supported Object Types
+
+The following object types are fully classified (the `ObjectType` field is set to the exact type name):
+
+- `TABLE`
+- `COLUMN`
+- `INDEX`
+- `SCHEMA`
+- `TYPE`
+- `DOMAIN`
+- `FOREIGN TABLE`
+- `VIEW`
+- `MATERIALIZED VIEW`
+- `SEQUENCE`
+
+The following object types produce `ObjectType: "UNKNOWN"`:
+
+- `FUNCTION`
+- `AGGREGATE`
+- `OPERATOR`
+- `CONSTRAINT`
+- `PROCEDURE`
+- `ROUTINE`
+- `TRANSFORM`
+- `OPERATOR CLASS`
+- `OPERATOR FAMILY`
+- `LARGE OBJECT`
+- `CAST`
+
+UNKNOWN types still parse the comment text correctly -- only the object type classification is degraded. The `Comment` field will contain the decoded comment string as expected. For example:
+
+```sql
+COMMENT ON FUNCTION public.my_func(integer) IS 'Does something';
+```
+
+produces `ObjectType: "UNKNOWN"` and `Comment: "Does something"`.
+
+## CREATE TABLE Inline `--` Field Comments (Option-Controlled)
+
+Inline field comments are disabled by default and enabled with:
+
+- `ParseSQLWithOptions`
+- `ParseSQLAllWithOptions`
+- `ParseSQLStrictWithOptions`
+
+using:
+
+```go
+postgresparser.ParseOptions{
+    IncludeCreateTableFieldComments: true,
+}
+```
+
+### Example SQL
+
+```sql
+CREATE TABLE public.users (
+    -- [Attribute("Just an example")]
+    -- required, min 5, max 55
+    name text,
+
+    -- single-column FK, inline
+    org_id integer REFERENCES public.organizations(id)
+);
+```
+
+### Behavior
+
+- consecutive `--` lines immediately above a column are captured
+- comments are trimmed and stored as `[]string`
+- comments above table constraints are not attached to columns
+
+### Performance Note
+
+`IncludeCreateTableFieldComments` is opt-in because it performs extra SQL text scanning for `CREATE TABLE`.
+
+In local benchmarks (`benchmark/bench_test.go`, `-benchmem`):
+- non-DDL queries (`SELECT`) showed no meaningful allocation overhead
+- `CREATE TABLE` parsing showed measurable overhead (roughly ~10-13% slower, with higher allocations)
+
+Use this option only when you need inline `--` field comment metadata.
+
+## Parser API Example
+
+```go
+opts := postgresparser.ParseOptions{
+    IncludeCreateTableFieldComments: true,
+}
+
+res, err := postgresparser.ParseSQLWithOptions(sql, opts)
+if err != nil {
+    log.Fatal(err)
+}
+
+for _, action := range res.DDLActions {
+    if action.Type == postgresparser.DDLComment {
+        fmt.Println(action.ObjectType, action.Target, action.Comment)
+    }
+}
+```
+
+## Analysis API Example
+
+The analysis layer reuses the same options type:
+
+```go
+opts := postgresparser.ParseOptions{
+    IncludeCreateTableFieldComments: true,
+}
+
+res, err := analysis.AnalyzeSQLWithOptions(sql, opts)
+if err != nil {
+    log.Fatal(err)
+}
+```

--- a/docs/supported-statements.md
+++ b/docs/supported-statements.md
@@ -25,6 +25,7 @@ These statements are walked via ANTLR visitors and produce rich IR metadata in `
 | `DROP TABLE` / `DROP INDEX` | `DDL` | `DDLActions` (with `Flags`) |
 | `CREATE INDEX` | `DDL` | `DDLActions` (with `IndexType`) |
 | `TRUNCATE` | `DDL` | `Tables`, `DDLActions` |
+| `COMMENT ON` | `DDL` | `DDLActions` (with `Type=COMMENT`, `ObjectType`, `ObjectName`, `Schema`, `Target`, `Comment`) |
 
 ## Gracefully Handled (UNKNOWN) Statements
 
@@ -60,8 +61,23 @@ Examples of statements that currently return errors or UNKNOWN without structure
 - `VACUUM` / `ANALYZE`
 - `BEGIN` / `COMMIT` / `ROLLBACK`
 - `LISTEN` / `NOTIFY`
-- `COMMENT ON`
 - `DO` (anonymous PL/pgSQL blocks)
+
+## Parse Options
+
+The parser exposes options-enabled entry points:
+
+- `ParseSQLWithOptions(sql, opts)`
+- `ParseSQLAllWithOptions(sql, opts)`
+- `ParseSQLStrictWithOptions(sql, opts)`
+
+Supported options:
+
+- `IncludeCreateTableFieldComments`:
+  - `false` (default): ignores inline `--` comments in `CREATE TABLE`.
+  - `true`: captures consecutive inline `--` lines immediately above each column into `DDLActions[].ColumnDetails[].Comment`.
+
+`COMMENT ON ...` extraction is always enabled and does not depend on options.
 
 ## Adding Support for New Statements
 

--- a/ir.go
+++ b/ir.go
@@ -124,6 +124,7 @@ const (
 	DDLCreateIndex DDLActionType = "CREATE_INDEX"
 	DDLDropIndex   DDLActionType = "DROP_INDEX"
 	DDLTruncate    DDLActionType = "TRUNCATE"
+	DDLComment     DDLActionType = "COMMENT"
 )
 
 // DDLColumn describes column-level metadata extracted from CREATE TABLE statements.
@@ -132,17 +133,21 @@ type DDLColumn struct {
 	Type     string
 	Nullable bool
 	Default  string
+	Comment  []string // Optional line comments immediately preceding column definition.
 }
 
 // DDLAction describes a single DDL operation extracted from a statement.
 type DDLAction struct {
 	Type          DDLActionType
 	ObjectName    string      // Unqualified table/index/object name
+	ObjectType    string      // TABLE, COLUMN, INDEX, ...
 	Schema        string      // Optional schema qualifier
 	Columns       []string    // Affected columns
 	ColumnDetails []DDLColumn // Column metadata (CREATE TABLE)
 	Flags         []string    // IF_EXISTS, CONCURRENTLY, CASCADE, etc.
 	IndexType     string      // btree, gin, gist, hash (CREATE INDEX only)
+	Target        string      // Generic fully-qualified target path for comment-like actions.
+	Comment       string      // Comment text for COMMENT ON statements.
 }
 
 // SubqueryRef records metadata for subqueries discovered in FROM or set operations.

--- a/options.go
+++ b/options.go
@@ -1,0 +1,8 @@
+package postgresparser
+
+// ParseOptions controls optional metadata extraction during parsing.
+type ParseOptions struct {
+	// IncludeCreateTableFieldComments enables extraction of line comments (`-- ...`)
+	// that immediately precede CREATE TABLE column definitions.
+	IncludeCreateTableFieldComments bool
+}


### PR DESCRIPTION
  Added COMMENT support in DDL parsing and analysis, with a minimal/generic contract:

  - Parse `COMMENT ON` statements into `DDLActions` (`TABLE`, `COLUMN`, `INDEX`, etc.)
  - Added generic comment fields: `ObjectType`, `Target`, `Comment`
  - Added optional CREATE TABLE inline field-comment extraction (`-- ...`) via parse
  options:
    - `ParseOptions.IncludeCreateTableFieldComments`
  - Kept COMMENT ON extraction always enabled (independent of options)
  - Added/expanded docs and benchmark coverage for option overhead

  ## Layer

  - [x] Core parser (`ir.go`, `ddl.go`, `select.go`, `dml_*.go`, `merge.go`,
  `setops.go`, `entry.go`)
  - [x] Analysis layer (`analysis/`)
  - [x] Docs / examples
  - [x] CI / tooling

  ## SQL examples

  ```sql
  -- Issue #34 examples
  COMMENT ON TABLE public.users IS 'Stores user account information';
  COMMENT ON COLUMN public.users.email IS 'User email address, must be unique';
  COMMENT ON INDEX public.idx_bookings_dates IS 'Composite index for efficient date
  range queries on bookings';

  -- Issue #25 example (option-controlled extraction)
  CREATE TABLE public.users (
    -- [Attribute("Just an example")]
    -- required, min 5, max 55
    name text,

    -- single-column FK, inline
    org_id integer REFERENCES public.organizations(id)
  );
  ```
  Example parsed shape for COMMENT ON COLUMN:

  {
    "type": "COMMENT",
    "object_type": "COLUMN",
    "schema": "public",
    "object_name": "users",
    "target": "public.users.email",
    "columns": ["email"],
    "comment": "User email address, must be unique"
  }

  ## Test plan

  - [x] New unit tests added
  - [x] Existing tests updated
  - [x] make test passes (race detector + coverage)
  - [x] make vet passes
  - [x] Manual verification with examples/

  Executed:

  - go test ./... -run 'TestIR_DDL_CommentOn_Table|TestAnalyzeSQL_DDL_CommentOn_Table'
    -count=1
  - Additional targeted parser/analysis table tests for COMMENT ON and field-comment
    options
  - Benchmarks for options overhead:
      - go test -run '^$' -bench 'BenchmarkPostgresParserWithOptions_(Default|
        FieldCommentsEnabled)$' -benchmem -benchtime=2s -count=5 (in benchmark/)

  ## Related issues

  Fixes #34
  Fixes #25

  ## Checklist

  - [x] No changes to gen/ (auto-generated ANTLR code)
  - [x] New IR fields documented in docs/parsed-query.md (if applicable)
  - [x] Public API additions are backward compatible