### PR TITLE
fix(table-COMMENTS): moved to token stream for comments instead regex

### DIFF
--- a/analysis/analysis_ddl_test.go
+++ b/analysis/analysis_ddl_test.go
@@ -854,6 +854,19 @@ func TestAnalyzeSQL_DDL_CreateTableFieldComments_Table(t *testing.T) {
 				"email": {"user email"},
 			},
 		},
+		{
+			name: "comment variants with spacing and dollar content",
+			sql: `CREATE TABLE public.users (
+    --    starts with spaces
+    --no-space-prefix
+    -- $tag marker
+    name text
+);`,
+			opts: postgresparser.ParseOptions{IncludeCreateTableFieldComments: true},
+			wantCommentsByCol: map[string][]string{
+				"name": {"starts with spaces", "no-space-prefix", "$tag marker"},
+			},
+		},
 	}
 
 	commentsByName := func(cols []SQLDDLColumn) map[string][]string {

--- a/ddl.go
+++ b/ddl.go
@@ -49,18 +49,15 @@ func populateCreateTable(result *ParsedQuery, ctx gen.ICreatestmtContext, tokens
 		Flags:      flags,
 	}
 
-	var fieldCommentsByColumn map[string][]string
-	if opts.IncludeCreateTableFieldComments {
-		if prc, ok := ctx.(antlr.RuleContext); ok {
-			fieldCommentsByColumn = extractCreateTableFieldCommentsByColumn(ctxText(tokens, prc))
-		}
-	}
-
 	if optElems := ctx.Opttableelementlist(); optElems != nil && optElems.Tableelementlist() != nil {
 		tableElems := optElems.Tableelementlist().AllTableelement()
 		action.Columns = make([]string, 0, len(tableElems))
 		action.ColumnDetails = make([]DDLColumn, 0, len(tableElems))
 		primaryKeyCols := collectCreateTablePrimaryKeyColumns(tableElems)
+		var fieldCommentsByColumn map[string][]string
+		if opts.IncludeCreateTableFieldComments {
+			fieldCommentsByColumn = extractCreateTableFieldCommentsByColumn(tableElems, tokens)
+		}
 		for _, tableElem := range tableElems {
 			if tableElem == nil || tableElem.ColumnDef() == nil {
 				continue

--- a/docs/comments.md
+++ b/docs/comments.md
@@ -126,7 +126,7 @@ CREATE TABLE public.users (
 
 ### Performance Note
 
-`IncludeCreateTableFieldComments` is opt-in because it performs extra SQL text scanning for `CREATE TABLE`.
+`IncludeCreateTableFieldComments` is opt-in because it performs extra hidden-token processing for `CREATE TABLE` column definitions.
 
 In local benchmarks (`benchmark/bench_test.go`, `-benchmem`):
 - non-DDL queries (`SELECT`) showed no meaningful allocation overhead


### PR DESCRIPTION
## Summary

  Refactored CREATE TABLE inline field-comment extraction to use ANTLR hidden
  tokens instead of manual SQL scanning.

  - Removed manual comment/body scanner logic for CREATE TABLE.
  - Added token-stream extraction using hidden-channel tokens adjacent to each
  column definition.
  - Kept behavior behind existing option flag:
    - `ParseOptions.IncludeCreateTableFieldComments`
  - Kept `COMMENT ON ...` extraction behavior unchanged.

  ## Why

  The old path duplicated lexer/parser responsibilities by re-scanning raw SQL
  text.
  ANTLR already tokenizes comments (`LineComment` / `BlockComment`) and exposes
  hidden tokens, so this refactor reduces maintenance risk and avoids double
  parsing logic.

  ## Implementation Details

  - `populateCreateTable` now calls:
    - `extractCreateTableFieldCommentsByColumn(tableElems, tokens)`
  - For each column:
    - use column start token index
    - collect hidden tokens on the left with `GetHiddenTokensToLeft`
    - keep only line comments (`PostgreSQLLexerLineComment`)
    - normalize comment text (strip `--`, trim spaces)
  - Block comments are intentionally ignored for field-comment extraction.

  ## Tests

  Added/updated table-driven tests to ensure parity and edge coverage:
  - Issue #25 exact example
  - default-disabled behavior
  - constraint comments not attached
  - comments with leading spaces
  - comments without space after `--`
  - comments containing `$` text
  - defaults with commas / complex expressions

  All tests pass:
  - `go test ./... -count=1`

  ## Related issues

  Fixes #25