### PR TITLE
feat(join-type): added table join type

### DIFF
--- a/analysis/analysis.go
+++ b/analysis/analysis.go
@@ -174,11 +174,13 @@ func convertTables(tbls []postgresparser.TableRef) []SQLTable {
 	out := make([]SQLTable, 0, len(tbls))
 	for _, t := range tbls {
 		out = append(out, SQLTable{
-			Schema: t.Schema,
-			Name:   t.Name,
-			Alias:  t.Alias,
-			Type:   SQLTableType(t.Type),
-			Raw:    t.Raw,
+			Schema:        t.Schema,
+			Name:          t.Name,
+			Alias:         t.Alias,
+			Type:          SQLTableType(t.Type),
+			Raw:           t.Raw,
+			JoinType:      t.JoinType,
+			JoinCondition: t.JoinCondition,
 		})
 	}
 	return out

--- a/analysis/analysis_coverage_test.go
+++ b/analysis/analysis_coverage_test.go
@@ -136,6 +136,88 @@ func TestAnalyze_JoinClauses_MultiColumnJoin(t *testing.T) {
 	assert.Contains(t, clause, "t2.b")
 }
 
+// TestAnalyze_JoinType_MultipleJoinTypes verifies that JoinType and JoinCondition
+// flow through the analysis layer on SQLTable for INNER, LEFT, and CROSS joins.
+func TestAnalyze_JoinType_MultipleJoinTypes(t *testing.T) {
+	sql := `SELECT u.id, o.id, p.name
+FROM users u
+INNER JOIN orders o ON u.id = o.user_id
+LEFT JOIN products p ON o.product_id = p.id
+CROSS JOIN settings s`
+
+	result, err := AnalyzeSQL(sql)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	require.Len(t, result.Tables, 4)
+	assert.Equal(t, "", result.Tables[0].JoinType, "base FROM table")
+	assert.Equal(t, "INNER", result.Tables[1].JoinType)
+	assert.Equal(t, "LEFT", result.Tables[2].JoinType)
+	assert.Equal(t, "CROSS", result.Tables[3].JoinType)
+
+	assert.Equal(t, "", result.Tables[0].JoinCondition)
+	assert.Contains(t, result.Tables[1].JoinCondition, "u.id = o.user_id")
+	assert.Contains(t, result.Tables[2].JoinCondition, "o.product_id = p.id")
+	assert.Equal(t, "", result.Tables[3].JoinCondition)
+}
+
+// TestAnalyze_JoinType_RightAndFull verifies RIGHT and FULL join types.
+func TestAnalyze_JoinType_RightAndFull(t *testing.T) {
+	sql := `SELECT a.id, b.id, c.id
+FROM alpha a
+RIGHT JOIN beta b ON a.id = b.alpha_id
+FULL JOIN gamma c ON b.id = c.beta_id`
+
+	result, err := AnalyzeSQL(sql)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	require.Len(t, result.Tables, 3)
+	assert.Equal(t, "RIGHT", result.Tables[1].JoinType)
+	assert.Equal(t, "FULL", result.Tables[2].JoinType)
+}
+
+// TestAnalyze_JoinType_NaturalJoin verifies NATURAL join propagation.
+func TestAnalyze_JoinType_NaturalJoin(t *testing.T) {
+	sql := `SELECT * FROM departments NATURAL JOIN employees`
+
+	result, err := AnalyzeSQL(sql)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	require.GreaterOrEqual(t, len(result.Tables), 2)
+	assert.Equal(t, "", result.Tables[0].JoinType)
+	assert.Equal(t, "NATURAL", result.Tables[1].JoinType)
+	assert.Equal(t, "", result.Tables[1].JoinCondition, "NATURAL JOIN has no explicit condition")
+}
+
+// TestAnalyze_JoinType_USING verifies bare JOIN with USING clause.
+func TestAnalyze_JoinType_USING(t *testing.T) {
+	sql := `SELECT * FROM orders o JOIN customers c USING (customer_id)`
+
+	result, err := AnalyzeSQL(sql)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	require.Len(t, result.Tables, 2)
+	assert.Equal(t, "JOIN", result.Tables[1].JoinType)
+	assert.Contains(t, result.Tables[1].JoinCondition, "USING")
+}
+
+// TestAnalyze_JoinType_BaseTables verifies that BaseTables helper preserves JoinType.
+func TestAnalyze_JoinType_BaseTables(t *testing.T) {
+	sql := `SELECT u.id FROM users u INNER JOIN orders o ON u.id = o.user_id`
+
+	result, err := AnalyzeSQL(sql)
+	require.NoError(t, err)
+
+	baseTbls := BaseTables(result)
+	require.Len(t, baseTbls, 2)
+	assert.Equal(t, "", baseTbls[0].JoinType)
+	assert.Equal(t, "INNER", baseTbls[1].JoinType)
+	assert.Contains(t, baseTbls[1].JoinCondition, "u.id = o.user_id")
+}
+
 // =============================================================================
 // 3. Parameters -- verify parameter metadata extraction
 // =============================================================================

--- a/analysis/helpers.go
+++ b/analysis/helpers.go
@@ -33,7 +33,7 @@ func BaseTables(a *SQLAnalysis) []SQLTable {
 			continue
 		}
 		seen[key] = struct{}{}
-		tables = append(tables, SQLTable{Schema: schema, Name: name, Alias: alias, Type: tbl.Type})
+		tables = append(tables, SQLTable{Schema: schema, Name: name, Alias: alias, Type: tbl.Type, JoinType: tbl.JoinType, JoinCondition: tbl.JoinCondition})
 	}
 	return tables
 }

--- a/analysis/types.go
+++ b/analysis/types.go
@@ -30,11 +30,13 @@ const (
 
 // SQLTable describes a relation referenced in the query.
 type SQLTable struct {
-	Schema string
-	Name   string
-	Alias  string
-	Type   SQLTableType
-	Raw    string
+	Schema        string
+	Name          string
+	Alias         string
+	Type          SQLTableType
+	Raw           string
+	JoinType      string // "INNER", "LEFT", "RIGHT", "FULL", "CROSS", "NATURAL", or "" for base FROM tables.
+	JoinCondition string // Raw ON/USING clause text, or "" for base/CROSS tables.
 }
 
 // SQLColumn records a projected expression and optional alias.

--- a/ir.go
+++ b/ir.go
@@ -54,11 +54,13 @@ const (
 
 // TableRef captures a table-like source referenced in a query.
 type TableRef struct {
-	Schema string
-	Name   string
-	Alias  string
-	Type   TableType
-	Raw    string
+	Schema        string
+	Name          string
+	Alias         string
+	Type          TableType
+	Raw           string
+	JoinType      string // "INNER", "LEFT", "RIGHT", "FULL", "CROSS", "NATURAL", or "" for base FROM tables.
+	JoinCondition string // Raw ON/USING clause text, or "" for base/CROSS tables.
 }
 
 // SelectColumn captures the projection list of a SELECT query.

--- a/parser_ir_edge_cases_test.go
+++ b/parser_ir_edge_cases_test.go
@@ -328,6 +328,18 @@ CROSS JOIN settings s`
 	for _, name := range expectedTables {
 		assert.True(t, containsTable(ir.Tables, name), "expected table %q", name)
 	}
+
+	// Verify JoinType on each TableRef.
+	assert.Equal(t, "", ir.Tables[0].JoinType, "base FROM table has no join type")
+	assert.Equal(t, "INNER", ir.Tables[1].JoinType)
+	assert.Equal(t, "LEFT", ir.Tables[2].JoinType)
+	assert.Equal(t, "CROSS", ir.Tables[3].JoinType)
+
+	// Verify JoinCondition on each TableRef.
+	assert.Equal(t, "", ir.Tables[0].JoinCondition)
+	assert.Contains(t, ir.Tables[1].JoinCondition, "u.id = o.user_id")
+	assert.Contains(t, ir.Tables[2].JoinCondition, "o.product_id = p.id")
+	assert.Equal(t, "", ir.Tables[3].JoinCondition, "CROSS JOIN has no condition")
 }
 
 // TestIR_JoinUSING confirms JOIN with USING clause.
@@ -341,6 +353,10 @@ JOIN employees e USING (department_id)`
 	require.Len(t, ir.Tables, 2, "expected 2 tables")
 	require.Len(t, ir.JoinConditions, 1, "expected 1 join condition")
 	assert.Contains(t, strings.ToUpper(ir.JoinConditions[0]), "USING", "expected USING in join condition")
+
+	// Bare JOIN is reported as "JOIN".
+	assert.Equal(t, "JOIN", ir.Tables[1].JoinType)
+	assert.Contains(t, ir.Tables[1].JoinCondition, "USING")
 }
 
 // ---------------------------------------------------------------------------
@@ -1025,6 +1041,9 @@ func TestIR_NaturalJoin(t *testing.T) {
 	require.Len(t, ir.Tables, 2, "expected 2 tables")
 	assert.True(t, containsTable(ir.Tables, "departments"), "expected departments")
 	assert.True(t, containsTable(ir.Tables, "employees"), "expected employees")
+
+	assert.Equal(t, "", ir.Tables[0].JoinType, "base table")
+	assert.Equal(t, "NATURAL", ir.Tables[1].JoinType)
 }
 
 // TestIR_SelfJoin confirms self-join produces two table references with distinct aliases.

--- a/parser_ir_select_test.go
+++ b/parser_ir_select_test.go
@@ -341,6 +341,10 @@ INNER JOIN customers c ON o.customer_id = c.id AND c.status = 'active'`
 	joinExpr := normalise(ir.JoinConditions[0])
 	assert.Contains(t, joinExpr, "o.customer_id=c.id", "unexpected join expression")
 	assert.Contains(t, joinExpr, "c.status='active'", "unexpected join expression")
+
+	assert.Equal(t, "", ir.Tables[0].JoinType, "base table")
+	assert.Equal(t, "INNER", ir.Tables[1].JoinType)
+	assert.Contains(t, ir.Tables[1].JoinCondition, "o.customer_id = c.id")
 }
 
 // TestIR_LeftJoinWithFunctions ensures LEFT JOIN filters and expressions persist.
@@ -360,6 +364,51 @@ LEFT JOIN purchases p ON u.id = p.user_id AND p.amount > 0`
 
 	require.Len(t, ir.JoinConditions, 1, "expected 1 join condition")
 	assert.Contains(t, ir.JoinConditions[0], "p.amount > 0", "unexpected join condition")
+
+	assert.Equal(t, "LEFT", ir.Tables[1].JoinType)
+	assert.Contains(t, ir.Tables[1].JoinCondition, "u.id = p.user_id")
+}
+
+// TestIR_JoinTypeAllVariants covers RIGHT, FULL, LEFT OUTER, and NATURAL LEFT joins.
+func TestIR_JoinTypeAllVariants(t *testing.T) {
+	sql := `
+SELECT a.id, b.id, c.id, d.id, e.id
+FROM alpha a
+RIGHT JOIN beta b ON a.id = b.alpha_id
+FULL JOIN gamma c ON b.id = c.beta_id
+LEFT OUTER JOIN delta d ON c.id = d.gamma_id
+NATURAL LEFT JOIN epsilon e`
+	ir := parseAssertNoError(t, sql)
+
+	require.Len(t, ir.Tables, 5)
+	assert.Equal(t, "", ir.Tables[0].JoinType)
+	assert.Equal(t, "RIGHT", ir.Tables[1].JoinType)
+	assert.Equal(t, "FULL", ir.Tables[2].JoinType)
+	assert.Equal(t, "LEFT", ir.Tables[3].JoinType)
+	assert.Equal(t, "NATURAL LEFT", ir.Tables[4].JoinType)
+
+	assert.Contains(t, ir.Tables[1].JoinCondition, "a.id = b.alpha_id")
+	assert.Contains(t, ir.Tables[2].JoinCondition, "b.id = c.beta_id")
+	assert.Contains(t, ir.Tables[3].JoinCondition, "c.id = d.gamma_id")
+	assert.Equal(t, "", ir.Tables[4].JoinCondition, "NATURAL JOIN has no explicit condition")
+}
+
+// TestIR_JoinTypeIssue29Example reproduces the exact example from issue #29.
+func TestIR_JoinTypeIssue29Example(t *testing.T) {
+	sql := `
+SELECT posts.id, users.name
+FROM users
+INNER JOIN posts ON posts.user_id = users.id
+WHERE users.id = $1`
+	ir := parseAssertNoError(t, sql)
+
+	require.Len(t, ir.Tables, 2)
+	assert.Equal(t, "users", ir.Tables[0].Name)
+	assert.Equal(t, "", ir.Tables[0].JoinType)
+
+	assert.Equal(t, "posts", ir.Tables[1].Name)
+	assert.Equal(t, "INNER", ir.Tables[1].JoinType)
+	assert.Contains(t, ir.Tables[1].JoinCondition, "posts.user_id = users.id")
 }
 
 // TestIR_FallbackToUnknown confirms unsupported statements still return UNKNOWN.

--- a/select.go
+++ b/select.go
@@ -408,8 +408,15 @@ func collectTableRefs(result *ParsedQuery, ref gen.ITable_refContext, tokens ant
 		}
 	}
 
-	for _, nested := range ref.AllTable_ref() {
+	metas := resolveJoinMeta(ref, tokens)
+	nestedRefs := ref.AllTable_ref()
+	for i, nested := range nestedRefs {
+		before := len(result.Tables)
 		collectTableRefs(result, nested, tokens, cteNames)
+		if i < len(metas) && before < len(result.Tables) {
+			result.Tables[before].JoinType = metas[i].joinType
+			result.Tables[before].JoinCondition = metas[i].joinCondition
+		}
 	}
 
 	for _, join := range ref.AllJoin_qual() {
@@ -427,6 +434,81 @@ func collectTableRefs(result *ParsedQuery, ref gen.ITable_refContext, tokens ant
 			findAndRecordUsage(result, joinCtx, ColumnUsageTypeJoin, tokens)
 		}
 	}
+}
+
+// joinMeta holds the resolved join type and condition for a nested table_ref.
+type joinMeta struct {
+	joinType      string
+	joinCondition string
+}
+
+// resolveJoinMeta walks the children of a table_ref node in parse order to
+// determine the join type and condition for each nested table_ref.
+// The returned slice is parallel to ref.AllTable_ref().
+func resolveJoinMeta(ref gen.ITable_refContext, tokens antlr.TokenStream) []joinMeta {
+	prc, ok := ref.(antlr.ParserRuleContext)
+	if !ok {
+		return nil
+	}
+
+	hasOpenParen := ref.OPEN_PAREN() != nil
+	seenFirstTableRef := false
+	pendingType := ""
+	var metas []joinMeta
+
+	for _, child := range prc.GetChildren() {
+		switch c := child.(type) {
+		case antlr.TerminalNode:
+			switch c.GetSymbol().GetTokenType() {
+			case gen.PostgreSQLParserCROSS:
+				pendingType = "CROSS"
+			case gen.PostgreSQLParserNATURAL:
+				pendingType = "NATURAL"
+			}
+		case *gen.Join_typeContext:
+			jt := joinTypeFromCtx(c)
+			if strings.HasPrefix(pendingType, "NATURAL") {
+				pendingType = "NATURAL " + jt
+			} else {
+				pendingType = jt
+			}
+		case *gen.Table_refContext:
+			if hasOpenParen && !seenFirstTableRef {
+				// Base table inside parentheses — no join type.
+				metas = append(metas, joinMeta{})
+				seenFirstTableRef = true
+			} else {
+				if pendingType == "" {
+					pendingType = "JOIN"
+				}
+				metas = append(metas, joinMeta{joinType: pendingType})
+			}
+			pendingType = ""
+		case *gen.Join_qualContext:
+			if len(metas) > 0 {
+				metas[len(metas)-1].joinCondition = strings.TrimSpace(ctxText(tokens, c))
+			}
+		}
+	}
+
+	return metas
+}
+
+// joinTypeFromCtx extracts a normalised join type string from a join_type rule context.
+func joinTypeFromCtx(ctx gen.IJoin_typeContext) string {
+	if ctx.FULL() != nil {
+		return "FULL"
+	}
+	if ctx.LEFT() != nil {
+		return "LEFT"
+	}
+	if ctx.RIGHT() != nil {
+		return "RIGHT"
+	}
+	if ctx.INNER_P() != nil {
+		return "INNER"
+	}
+	return ""
 }
 
 // extractWhereClause appends WHERE predicates to the ParsedQuery.


### PR DESCRIPTION
Summary

  - Add JoinType and JoinCondition fields to TableRef (parser) and SQLTable
  (analysis) so consumers can determine how each table participates in a query
  - Walks ANTLR table_ref children in parse order to resolve join metadata — no
  grammar changes needed
  - Supports INNER, LEFT, RIGHT, FULL, CROSS, NATURAL, NATURAL LEFT, and bare
  JOIN

  Layer

  - Core parser (ir.go, ddl.go, select.go, dml_*.go, merge.go, setops.go,
  entry.go)
  - Analysis layer (analysis/)
  - Docs / examples
  - CI / tooling

  SQL examples

```
  SELECT posts.id, users.name
  FROM users u
  INNER JOIN posts p ON p.user_id = u.id
  LEFT JOIN comments c ON c.post_id = p.id
  CROSS JOIN settings s
```

  Before: Tables had Name/Alias but no join info. Consumers had to index-match
  JoinConditions[] separately.

  After:
```
  Tables[0] → {Name: "users",    Alias: "u", JoinType: "",      JoinCondition:
  ""}
  Tables[1] → {Name: "posts",    Alias: "p", JoinType: "INNER", JoinCondition:
  "ON p.user_id = u.id"}
  Tables[2] → {Name: "comments", Alias: "c", JoinType: "LEFT",  JoinCondition:
  "ON c.post_id = p.id"}
  Tables[3] → {Name: "settings", Alias: "s", JoinType: "CROSS", JoinCondition:
  ""}
```

  Test plan

  - New unit tests added
  - Existing tests updated
  - make test passes (race detector + coverage)
  - make vet passes
  - Manual verification with examples/

  Related issues

  Fixes #29

  Checklist

  - No changes to gen/ (auto-generated ANTLR code)
  - New IR fields documented in docs/parsed-query.md (if applicable)
  - Public API additions are backward compatible