### PR TITLE
fix(select): scope subquery column usage to nested queries

### DIFF
--- a/analysis/analysis_coverage_test.go
+++ b/analysis/analysis_coverage_test.go
@@ -372,6 +372,64 @@ func TestAnalyze_Subqueries_DerivedTable(t *testing.T) {
 	assert.Equal(t, "name", sub.Analysis.Columns[1].Expression)
 }
 
+// TestAnalyze_Subqueries_ScalarWhereScope verifies that scalar subqueries in
+// WHERE clauses are captured under Subqueries and do not leak inner ColumnUsage
+// into the outer analysis scope.
+func TestAnalyze_Subqueries_ScalarWhereScope(t *testing.T) {
+	sql := `SELECT id, name FROM users WHERE id IN (SELECT user_id FROM orders WHERE total > 500)`
+
+	result, err := AnalyzeSQL(sql)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	require.Len(t, result.Tables, 1, "Outer analysis should reference only the users table")
+	assert.Equal(t, "users", result.Tables[0].Name)
+
+	require.Len(t, result.Subqueries, 1, "Should detect one scalar subquery")
+	sub := result.Subqueries[0]
+	assert.Equal(t, "", sub.Alias, "Scalar subquery alias should be empty")
+	require.NotNil(t, sub.Analysis, "Scalar subquery analysis should not be nil")
+	require.Len(t, sub.Analysis.Tables, 1, "Nested analysis should reference one table")
+	assert.Equal(t, "orders", sub.Analysis.Tables[0].Name)
+
+	var outerHasIDProjection, outerHasNameProjection, outerHasIDFilter bool
+	var outerHasUserID, outerHasTotal bool
+	for _, usage := range result.ColumnUsage {
+		if usage.Column == "id" && usage.UsageType == SQLUsageTypeProjection {
+			outerHasIDProjection = true
+		}
+		if usage.Column == "name" && usage.UsageType == SQLUsageTypeProjection {
+			outerHasNameProjection = true
+		}
+		if usage.Column == "id" && usage.UsageType == SQLUsageTypeFilter {
+			outerHasIDFilter = true
+		}
+		if usage.Column == "user_id" {
+			outerHasUserID = true
+		}
+		if usage.Column == "total" {
+			outerHasTotal = true
+		}
+	}
+	assert.True(t, outerHasIDProjection, "Outer analysis should include projection usage for id")
+	assert.True(t, outerHasNameProjection, "Outer analysis should include projection usage for name")
+	assert.True(t, outerHasIDFilter, "Outer analysis should include filter usage for id")
+	assert.False(t, outerHasUserID, "Subquery column user_id should not leak into outer scope")
+	assert.False(t, outerHasTotal, "Subquery column total should not leak into outer scope")
+
+	var innerHasUserIDProjection, innerHasTotalFilter bool
+	for _, usage := range sub.Analysis.ColumnUsage {
+		if usage.Column == "user_id" && usage.UsageType == SQLUsageTypeProjection {
+			innerHasUserIDProjection = true
+		}
+		if usage.Column == "total" && usage.UsageType == SQLUsageTypeFilter {
+			innerHasTotalFilter = true
+		}
+	}
+	assert.True(t, innerHasUserIDProjection, "Nested analysis should include projection usage for user_id")
+	assert.True(t, innerHasTotalFilter, "Nested analysis should include filter usage for total")
+}
+
 // TestAnalyze_Subqueries_LateralWithNestedAnalysis verifies that a LATERAL
 // subquery captures nested analysis with its own tables, columns, and filters.
 func TestAnalyze_Subqueries_LateralWithNestedAnalysis(t *testing.T) {

--- a/analysis/analysis_edge_cases_test.go
+++ b/analysis/analysis_edge_cases_test.go
@@ -317,7 +317,7 @@ func TestAnalyzeNestedSubqueries(t *testing.T) {
 	// Should detect nested structure
 	assert.NotEmpty(t, result.Subqueries, "Should detect subqueries")
 
-	// Should find filter columns at various levels
+	// Outer scope should keep only outer-level filter usage.
 	var hasCountryFilter, hasItemCountFilter bool
 	for _, usage := range result.ColumnUsage {
 		if usage.UsageType == SQLUsageTypeFilter {
@@ -329,9 +329,27 @@ func TestAnalyzeNestedSubqueries(t *testing.T) {
 			}
 		}
 	}
-	assert.True(t, hasCountryFilter, "Should detect country filter in nested subquery")
-	// item_count might not be detected as it's from derived table
+	assert.False(t, hasCountryFilter, "Nested country filter should not leak into outer scope")
 	_ = hasItemCountFilter
+
+	var nestedHasCountryFilter func(subqueries []SQLSubquery) bool
+	nestedHasCountryFilter = func(subqueries []SQLSubquery) bool {
+		for _, sub := range subqueries {
+			if sub.Analysis == nil {
+				continue
+			}
+			for _, usage := range sub.Analysis.ColumnUsage {
+				if usage.UsageType == SQLUsageTypeFilter && usage.Column == "country" {
+					return true
+				}
+			}
+			if nestedHasCountryFilter(sub.Analysis.Subqueries) {
+				return true
+			}
+		}
+		return false
+	}
+	assert.True(t, nestedHasCountryFilter(result.Subqueries), "Should detect country filter inside nested subquery scope")
 }
 
 // TestAnalyzeLateralJoin validates correlated LATERAL subquery detection.
@@ -351,18 +369,33 @@ func TestAnalyzeLateralJoin(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
-	// LATERAL might be treated as subquery or function
-	assert.GreaterOrEqual(t, len(result.Tables), 1)
+	require.NotEmpty(t, result.Subqueries, "Should detect the LATERAL subquery")
 
-	// Should detect correlation
-	var hasUserIdUsage bool
+	var outerHasUserID bool
 	for _, usage := range result.ColumnUsage {
 		if usage.Column == "user_id" {
-			hasUserIdUsage = true
+			outerHasUserID = true
 			break
 		}
 	}
-	assert.True(t, hasUserIdUsage, "Should detect correlated user_id")
+	assert.False(t, outerHasUserID, "Inner LATERAL usage should not leak into outer scope")
+
+	var nestedHasUserID, nestedHasOuterID bool
+	for _, sub := range result.Subqueries {
+		if sub.Analysis == nil {
+			continue
+		}
+		for _, usage := range sub.Analysis.ColumnUsage {
+			if usage.UsageType == SQLUsageTypeFilter && usage.TableAlias == "o" && usage.Column == "user_id" {
+				nestedHasUserID = true
+			}
+			if usage.UsageType == SQLUsageTypeFilter && usage.TableAlias == "u" && usage.Column == "id" {
+				nestedHasOuterID = true
+			}
+		}
+	}
+	assert.True(t, nestedHasUserID, "Nested LATERAL analysis should capture orders.user_id")
+	assert.True(t, nestedHasOuterID, "Nested LATERAL analysis should capture correlated outer alias usage")
 }
 
 // TestAnalyzeInsertMultipleValues verifies multi-row INSERT with ON CONFLICT and RETURNING.

--- a/analysis/analysis_table_alias_test.go
+++ b/analysis/analysis_table_alias_test.go
@@ -42,7 +42,7 @@ func TestAnalyze_PreserveTableAlias(t *testing.T) {
 }
 
 // TestAnalyze_PreserveTableAliasInSubquery tests that table aliases are preserved
-// in IN subqueries that reference the same column name from different contexts.
+// in IN subqueries without leaking inner filter usage into the outer scope.
 func TestAnalyze_PreserveTableAliasInSubquery(t *testing.T) {
 	sql := `SELECT * FROM orders o
 		WHERE o.customer_id IN (
@@ -53,29 +53,27 @@ func TestAnalyze_PreserveTableAliasInSubquery(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
-	// Find all filter usages for "status" column
-	var statusFilters []SQLColumnUsage
+	// Outer scope should keep only the orders.status filter.
+	var outerStatusFilters []SQLColumnUsage
 	for _, usage := range result.ColumnUsage {
 		if usage.UsageType == SQLUsageTypeFilter && usage.Column == "status" {
-			statusFilters = append(statusFilters, usage)
+			outerStatusFilters = append(outerStatusFilters, usage)
 		}
 	}
+	require.Len(t, outerStatusFilters, 1, "Outer scope should keep only one status filter")
+	assert.Equal(t, "o", outerStatusFilters[0].TableAlias, "Outer status filter should keep alias 'o'")
 
-	// We should have TWO separate filter entries for status
-	assert.GreaterOrEqual(t, len(statusFilters), 2, "Should have at least two status filter entries")
+	require.Len(t, result.Subqueries, 1, "Should capture the IN subquery")
+	require.NotNil(t, result.Subqueries[0].Analysis, "Subquery analysis should be present")
 
-	// Check that at least one has table alias 'o' and one has 'c'
-	var hasO, hasC bool
-	for _, filter := range statusFilters {
-		if filter.TableAlias == "o" {
-			hasO = true
-		}
-		if filter.TableAlias == "c" {
-			hasC = true
+	var nestedStatusFilters []SQLColumnUsage
+	for _, usage := range result.Subqueries[0].Analysis.ColumnUsage {
+		if usage.UsageType == SQLUsageTypeFilter && usage.Column == "status" {
+			nestedStatusFilters = append(nestedStatusFilters, usage)
 		}
 	}
-	assert.True(t, hasO, "Should have status filter with alias 'o'")
-	assert.True(t, hasC, "Should have status filter with alias 'c'")
+	require.Len(t, nestedStatusFilters, 1, "Nested scope should keep the customer status filter")
+	assert.Equal(t, "c", nestedStatusFilters[0].TableAlias, "Nested status filter should keep alias 'c'")
 }
 
 // TestAnalyze_MultipleOperatorsOnSameColumn tests that multiple operators on the same column

--- a/helpers.go
+++ b/helpers.go
@@ -23,11 +23,29 @@ type columnRef struct {
 // columnRefCollector walks the subtree and records every column reference encountered.
 type columnRefCollector struct {
 	*gen.BasePostgreSQLParserListener
-	refs []*gen.ColumnrefContext
+	refs          []*gen.ColumnrefContext
+	subqueryDepth int
 }
 
 func (c *columnRefCollector) EnterColumnref(ctx *gen.ColumnrefContext) {
+	if c.subqueryDepth > 0 {
+		return
+	}
 	c.refs = append(c.refs, ctx)
+}
+
+// EnterSelect_with_parens increments nested subquery depth so outer scope
+// usage collection ignores inner SELECT bodies.
+func (c *columnRefCollector) EnterSelect_with_parens(ctx *gen.Select_with_parensContext) {
+	c.subqueryDepth++
+}
+
+// ExitSelect_with_parens decrements nested subquery depth after leaving an
+// inner SELECT body.
+func (c *columnRefCollector) ExitSelect_with_parens(ctx *gen.Select_with_parensContext) {
+	if c.subqueryDepth > 0 {
+		c.subqueryDepth--
+	}
 }
 
 // windowClauseCollector walks the subtree and records window function OVER clauses.
@@ -38,6 +56,30 @@ type windowClauseCollector struct {
 
 func (w *windowClauseCollector) EnterOver_clause(ctx *gen.Over_clauseContext) {
 	w.overClauses = append(w.overClauses, ctx)
+}
+
+// expressionSubqueryCollector records only direct subqueries for the current
+// expression scope, leaving nested subqueries to the subquery's own ParsedQuery.
+type expressionSubqueryCollector struct {
+	*gen.BasePostgreSQLParserListener
+	subqueries    []gen.ISelect_with_parensContext
+	subqueryDepth int
+}
+
+// EnterSelect_with_parens records only direct subqueries in the current
+// expression and defers nested ones to the subquery's own parse pass.
+func (c *expressionSubqueryCollector) EnterSelect_with_parens(ctx *gen.Select_with_parensContext) {
+	if c.subqueryDepth == 0 {
+		c.subqueries = append(c.subqueries, ctx)
+	}
+	c.subqueryDepth++
+}
+
+// ExitSelect_with_parens decrements the current nested subquery depth.
+func (c *expressionSubqueryCollector) ExitSelect_with_parens(ctx *gen.Select_with_parensContext) {
+	if c.subqueryDepth > 0 {
+		c.subqueryDepth--
+	}
 }
 
 // findAndRecordUsage finds all column references within a given context and adds them to the ParsedQuery with the specified role.
@@ -84,6 +126,30 @@ func findAndRecordUsage(result *ParsedQuery, ctx antlr.RuleContext, role ColumnU
 		usage.Functions = extractFunctionsFromContext(ctx, colCtx, tokens)
 
 		result.ColumnUsage = append(result.ColumnUsage, usage)
+	}
+}
+
+// extractExpressionSubqueries captures direct scalar subqueries in an
+// expression and stores them under result.Subqueries without flattening their
+// nested ColumnUsage into the parent query.
+func extractExpressionSubqueries(result *ParsedQuery, ctx antlr.RuleContext, tokens antlr.TokenStream) {
+	if result == nil || ctx == nil {
+		return
+	}
+
+	tree, ok := ctx.(antlr.ParseTree)
+	if !ok {
+		return
+	}
+
+	collector := &expressionSubqueryCollector{BasePostgreSQLParserListener: &gen.BasePostgreSQLParserListener{}}
+	antlr.ParseTreeWalkerDefault.Walk(collector, tree)
+	for _, selectWithParens := range collector.subqueries {
+		subRef, err := buildSubqueryRef("", selectWithParens, tokens)
+		if err != nil || subRef == nil {
+			continue
+		}
+		result.Subqueries = append(result.Subqueries, *subRef)
 	}
 }
 

--- a/helpers_comparison.go
+++ b/helpers_comparison.go
@@ -23,13 +23,31 @@ type comparisonInfo struct {
 // to properly extract operators from deeply nested parse trees.
 type comprehensiveComparisonCollector struct {
 	*gen.BasePostgreSQLParserListener
-	comparisons []comparisonInfo
-	tokens      antlr.TokenStream
+	comparisons   []comparisonInfo
+	tokens        antlr.TokenStream
+	subqueryDepth int
+}
+
+// EnterSelect_with_parens increments nested subquery depth so outer comparison
+// extraction ignores inner SELECT bodies.
+func (c *comprehensiveComparisonCollector) EnterSelect_with_parens(ctx *gen.Select_with_parensContext) {
+	c.subqueryDepth++
+}
+
+// ExitSelect_with_parens decrements nested subquery depth after leaving an
+// inner SELECT body.
+func (c *comprehensiveComparisonCollector) ExitSelect_with_parens(ctx *gen.Select_with_parensContext) {
+	if c.subqueryDepth > 0 {
+		c.subqueryDepth--
+	}
 }
 
 // EnterA_expr_compare handles comparison operators like >, <, =, etc.
 func (c *comprehensiveComparisonCollector) EnterA_expr_compare(ctx *gen.A_expr_compareContext) {
 	if ctx == nil {
+		return
+	}
+	if c.subqueryDepth > 0 {
 		return
 	}
 
@@ -66,6 +84,9 @@ func (c *comprehensiveComparisonCollector) EnterA_expr_compare(ctx *gen.A_expr_c
 // EnterA_expr_like handles LIKE and ILIKE operators
 func (c *comprehensiveComparisonCollector) EnterA_expr_like(ctx *gen.A_expr_likeContext) {
 	if ctx == nil {
+		return
+	}
+	if c.subqueryDepth > 0 {
 		return
 	}
 
@@ -110,6 +131,9 @@ func (c *comprehensiveComparisonCollector) EnterA_expr_in(ctx *gen.A_expr_inCont
 	if ctx == nil {
 		return
 	}
+	if c.subqueryDepth > 0 {
+		return
+	}
 
 	exprText := ctxText(c.tokens, ctx)
 	operator := ""
@@ -152,6 +176,9 @@ func (c *comprehensiveComparisonCollector) EnterA_expr_between(ctx *gen.A_expr_b
 	if ctx == nil {
 		return
 	}
+	if c.subqueryDepth > 0 {
+		return
+	}
 
 	exprText := ctxText(c.tokens, ctx)
 	operator := ""
@@ -192,6 +219,9 @@ func (c *comprehensiveComparisonCollector) EnterA_expr_between(ctx *gen.A_expr_b
 // EnterA_expr_isnull handles IS NULL and IS NOT NULL
 func (c *comprehensiveComparisonCollector) EnterA_expr_isnull(ctx *gen.A_expr_isnullContext) {
 	if ctx == nil {
+		return
+	}
+	if c.subqueryDepth > 0 {
 		return
 	}
 
@@ -264,6 +294,9 @@ func (c *comprehensiveComparisonCollector) EnterA_expr_is_not(ctx *gen.A_expr_is
 	if ctx == nil {
 		return
 	}
+	if c.subqueryDepth > 0 {
+		return
+	}
 
 	exprText := ctxText(c.tokens, ctx)
 	operator := ""
@@ -315,6 +348,9 @@ func (c *comprehensiveComparisonCollector) EnterA_expr_is_not(ctx *gen.A_expr_is
 // EnterA_expr_qual_op handles qualified operators (schema.operator)
 func (c *comprehensiveComparisonCollector) EnterA_expr_qual_op(ctx *gen.A_expr_qual_opContext) {
 	if ctx == nil {
+		return
+	}
+	if c.subqueryDepth > 0 {
 		return
 	}
 

--- a/merge.go
+++ b/merge.go
@@ -66,8 +66,9 @@ func populateMerge(result *ParsedQuery, ctx gen.IMergestmtContext, tokens antlr.
 			Raw:   raw,
 		}
 		appendSetOpTables(result, nil, []TableRef{merge.Source.Table})
-		// Use buildSubqueryRefWithResult to propagate column usage from nested subqueries
-		if subRef, err := buildSubqueryRefWithResult(sourceAlias, swp, tokens, result); err == nil && subRef != nil {
+		// Build nested subquery analysis without flattening inner column usage
+		// into the MERGE parent scope.
+		if subRef, err := buildSubqueryRef(sourceAlias, swp, tokens); err == nil && subRef != nil {
 			merge.Source.Subquery = subRef
 			result.Subqueries = append(result.Subqueries, *subRef)
 			appendSetOpTables(result, nil, subRef.Query.Tables)

--- a/parser_ir_select_test.go
+++ b/parser_ir_select_test.go
@@ -57,6 +57,59 @@ func TestIR_AggregateFunctions(t *testing.T) {
 	assert.Equal(t, "status='shipped'", normalise(ir.Where[0]), "unexpected WHERE clause")
 }
 
+// TestIR_SubqueryInWhere_ScopesColumnUsage ensures scalar subqueries in WHERE
+// populate Subqueries and keep inner ColumnUsage out of the outer query scope.
+func TestIR_SubqueryInWhere_ScopesColumnUsage(t *testing.T) {
+	sql := `SELECT id, name FROM users WHERE id IN (SELECT user_id FROM orders WHERE total > 500)`
+	ir := parseAssertNoError(t, sql)
+
+	assert.Equal(t, QueryCommandSelect, ir.Command, "expected command SELECT")
+	require.Len(t, ir.Tables, 1, "expected only outer table")
+	assert.Equal(t, "users", ir.Tables[0].Name, "unexpected outer table")
+
+	require.Len(t, ir.Subqueries, 1, "expected one scalar subquery")
+	assert.Empty(t, ir.Subqueries[0].Alias, "expected empty alias for scalar subquery")
+	require.NotNil(t, ir.Subqueries[0].Query, "expected parsed subquery")
+	assert.True(t, containsTable(ir.Subqueries[0].Query.Tables, "orders"), "expected orders table in subquery")
+
+	var outerHasIDProjection, outerHasNameProjection, outerHasIDFilter bool
+	var outerHasUserID, outerHasTotal bool
+	for _, usage := range ir.ColumnUsage {
+		if usage.Column == "id" && usage.UsageType == ColumnUsageTypeProjection {
+			outerHasIDProjection = true
+		}
+		if usage.Column == "name" && usage.UsageType == ColumnUsageTypeProjection {
+			outerHasNameProjection = true
+		}
+		if usage.Column == "id" && usage.UsageType == ColumnUsageTypeFilter {
+			outerHasIDFilter = true
+		}
+		if usage.Column == "user_id" {
+			outerHasUserID = true
+		}
+		if usage.Column == "total" {
+			outerHasTotal = true
+		}
+	}
+	assert.True(t, outerHasIDProjection, "expected outer projection usage for id")
+	assert.True(t, outerHasNameProjection, "expected outer projection usage for name")
+	assert.True(t, outerHasIDFilter, "expected outer filter usage for id")
+	assert.False(t, outerHasUserID, "unexpected leaked subquery column user_id in outer scope")
+	assert.False(t, outerHasTotal, "unexpected leaked subquery column total in outer scope")
+
+	var innerHasUserIDProjection, innerHasTotalFilter bool
+	for _, usage := range ir.Subqueries[0].Query.ColumnUsage {
+		if usage.Column == "user_id" && usage.UsageType == ColumnUsageTypeProjection {
+			innerHasUserIDProjection = true
+		}
+		if usage.Column == "total" && usage.UsageType == ColumnUsageTypeFilter {
+			innerHasTotalFilter = true
+		}
+	}
+	assert.True(t, innerHasUserIDProjection, "expected user_id projection usage in subquery scope")
+	assert.True(t, innerHasTotalFilter, "expected total filter usage in subquery scope")
+}
+
 // TestIR_ArithmeticInProjection checks arithmetic expressions in projections.
 func TestIR_ArithmeticInProjection(t *testing.T) {
 	sql := `SELECT price * quantity AS total_cost FROM orders`

--- a/select.go
+++ b/select.go
@@ -285,6 +285,7 @@ func extractProjection(result *ParsedQuery, simple gen.ISimple_select_pramaryCon
 					expr = strings.TrimSpace(ctxText(tokens, prc))
 				}
 				findAndRecordUsage(result, col.A_expr(), ColumnUsageTypeProjection, tokens)
+				extractExpressionSubqueries(result, col.A_expr(), tokens)
 			}
 			alias := ""
 			switch {
@@ -401,8 +402,9 @@ func collectTableRefs(result *ParsedQuery, ref gen.ITable_refContext, tokens ant
 			Type:  TableTypeSubquery,
 			Raw:   raw,
 		})
-		// Use buildSubqueryRefWithResult to propagate column usage from nested subqueries
-		if subRef, err := buildSubqueryRefWithResult(alias, sub, tokens, result); err == nil && subRef != nil {
+		// Build nested subquery analysis without flattening inner column usage
+		// into the parent query scope.
+		if subRef, err := buildSubqueryRef(alias, sub, tokens); err == nil && subRef != nil {
 			result.Subqueries = append(result.Subqueries, *subRef)
 			appendSetOpTables(result, nil, subRef.Query.Tables)
 		}
@@ -523,6 +525,7 @@ func extractWhereClause(result *ParsedQuery, whereCtx gen.IWhere_clauseContext, 
 		}
 		clauseText := strings.TrimSpace(ctxText(tokens, prc))
 		result.Where = append(result.Where, clauseText)
+		extractExpressionSubqueries(result, expr, tokens)
 		// Use the new comparison-aware extraction for WHERE clauses
 		findAndRecordComparisons(result, expr, ColumnUsageTypeFilter, tokens)
 	}
@@ -537,6 +540,7 @@ func extractHavingClause(result *ParsedQuery, havingCtx gen.IHaving_clauseContex
 		if prc, ok := expr.(antlr.ParserRuleContext); ok {
 			result.Having = append(result.Having, strings.TrimSpace(ctxText(tokens, prc)))
 		}
+		extractExpressionSubqueries(result, expr, tokens)
 		// Use the new comparison-aware extraction for HAVING clauses
 		findAndRecordComparisons(result, expr, ColumnUsageTypeFilter, tokens)
 	}

--- a/setops.go
+++ b/setops.go
@@ -299,8 +299,9 @@ func extractTablesAndUsageForPrimary(primary gen.ISimple_select_pramaryContext, 
 		})
 	}
 	if primary.Select_with_parens() != nil {
-		// Use targetResult to propagate column usage from nested subqueries
-		if subRef, err := buildSubqueryRefWithResult("", primary.Select_with_parens(), tokens, targetResult); err == nil && subRef != nil {
+		// Build nested subquery analysis without flattening inner column usage
+		// into the parent query scope.
+		if subRef, err := buildSubqueryRef("", primary.Select_with_parens(), tokens); err == nil && subRef != nil {
 			tmp.Subqueries = append(tmp.Subqueries, *subRef)
 			tmp.Tables = append(tmp.Tables, subRef.Query.Tables...)
 		}
@@ -308,8 +309,8 @@ func extractTablesAndUsageForPrimary(primary gen.ISimple_select_pramaryContext, 
 	return tmp.Tables, tmp.Subqueries
 }
 
-// buildSubqueryRefWithResult parses a parenthesised subquery and optionally propagates column usage.
-func buildSubqueryRefWithResult(alias string, selectWithParens gen.ISelect_with_parensContext, tokens antlr.TokenStream, result *ParsedQuery) (*SubqueryRef, error) {
+// buildSubqueryRef parses a parenthesised subquery into nested IR.
+func buildSubqueryRef(alias string, selectWithParens gen.ISelect_with_parensContext, tokens antlr.TokenStream) (*SubqueryRef, error) {
 	if selectWithParens == nil {
 		return nil, nil
 	}
@@ -331,11 +332,6 @@ func buildSubqueryRefWithResult(alias string, selectWithParens gen.ISelect_with_
 	}
 	if err := populateSelectFromResolvedNested(parsed, withClause, simple, selectNoParens, tokens, true); err != nil {
 		return nil, err
-	}
-
-	// Propagate column usage from subquery to parent result
-	if result != nil && parsed != nil {
-		result.ColumnUsage = append(result.ColumnUsage, parsed.ColumnUsage...)
 	}
 
 	return &SubqueryRef{


### PR DESCRIPTION
## Summary

- fixes #45 by keeping subquery `ColumnUsage` scoped to the nested query that owns it
- captures scalar subqueries in expression contexts under `Subqueries` instead of flattening their column usage into the parent query
- updates analysis regressions for scalar subqueries, nested subqueries, and LATERAL/correlated cases to assert the corrected scope split

Compatibility note: this is a behavior correction, not a schema/API break. If anyone relied on the old flattened outer-scope `ColumnUsage`, they now need to read nested usage from `Subqueries[].Query.ColumnUsage` in the parser IR or `Subqueries[].Analysis.ColumnUsage` in the analysis layer.

No ANTLR or `gen/` changes were required.

## Layer

- [x] Core parser (`ir.go`, `ddl.go`, `select.go`, `dml_*.go`, `merge.go`, `setops.go`, `entry.go`)
- [x] Analysis layer (`analysis/`)
- [x] Docs / examples
- [x] CI / tooling

## SQL examples

```sql
SELECT id, name
FROM users
WHERE id IN (
  SELECT user_id
  FROM orders
  WHERE total > 500
);
```

Before:
- outer `ColumnUsage` included `user_id` and `total`
- scalar subquery handling in this path did not preserve the nested scope correctly

After:
- outer `ColumnUsage` contains only outer-scope usage such as `id` and `name`
- nested usage lives under `Subqueries[0].Query.ColumnUsage`
- analysis mirrors the same split under `Subqueries[0].Analysis.ColumnUsage`

## Test plan

- [x] New unit tests added
- [x] Existing tests updated
- [x] `make test` passes (race detector + coverage)
- [x] `make vet` passes
- [x] Manual verification with `examples/`

## Related issues

Fixes #45

## Checklist

- [x] No changes to `gen/` (auto-generated ANTLR code)
- [ ] New IR fields documented in `docs/parsed-query.md` (if applicable)
- [x] Public API additions are backward compatible
