### PR TITLE
feat(constraint): added CheckConstraints docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ go get github.com/valkdb/postgresparser
 Handles the SQL you actually write in production:
 
 - **DML**: SELECT, INSERT, UPDATE, DELETE, MERGE
-- **DDL**: CREATE TABLE (columns/type/nullability/default + PK/FK/UNIQUE constraints), CREATE INDEX, DROP TABLE/INDEX, ALTER TABLE, TRUNCATE, COMMENT ON
+- **DDL**: CREATE TABLE (columns/type/nullability/default + PK/FK/UNIQUE/CHECK constraints), CREATE INDEX, DROP TABLE/INDEX, ALTER TABLE, TRUNCATE, COMMENT ON
 - **CTEs**: `WITH ... AS` including `RECURSIVE`, materialization hints
 - **JOINs**: INNER, LEFT, RIGHT, FULL, CROSS, NATURAL, LATERAL
 - **Subqueries**: in SELECT, FROM, WHERE, and HAVING

--- a/analysis/analysis_ddl_test.go
+++ b/analysis/analysis_ddl_test.go
@@ -1421,6 +1421,41 @@ func TestAnalyzeSQL_DDL_CreateTableWithCheckConstraint(t *testing.T) {
 			);`,
 			wantChecks: 2,
 		},
+		{
+			name: "issue #32 — pg_dump style with ANY()",
+			sql: `CREATE TABLE public.store_settings (
+				id boolean DEFAULT true NOT NULL,
+				active_languages text[] NOT NULL,
+				default_language text NOT NULL,
+				max_players_per_team integer NOT NULL,
+				timezone text NOT NULL,
+				CONSTRAINT store_settings_check CHECK ((default_language = ANY (active_languages))),
+				CONSTRAINT store_settings_id_check CHECK ((id = true))
+			);`,
+			wantChecks:     2,
+			wantConstraint: "store_settings_check",
+			wantExpr:       "(default_language = ANY (active_languages))",
+		},
+		{
+			name: "CHECK with boolean expression and nested parens",
+			sql: `CREATE TABLE public.events (
+				start_date date NOT NULL,
+				end_date date NOT NULL,
+				CONSTRAINT valid_dates CHECK ((end_date > start_date))
+			);`,
+			wantChecks:     1,
+			wantConstraint: "valid_dates",
+			wantExpr:       "(end_date > start_date)",
+		},
+		{
+			name: "CHECK with OR and function call",
+			sql: `CREATE TABLE public.users (
+				email text NOT NULL,
+				CONSTRAINT valid_email CHECK ((email ~~ '%@%'::text) OR (length(email) > 5))
+			);`,
+			wantChecks:     1,
+			wantConstraint: "valid_email",
+		},
 	}
 
 	for _, tc := range tests {
@@ -1444,6 +1479,48 @@ func TestAnalyzeSQL_DDL_CreateTableWithCheckConstraint(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestAnalyzeSQL_DDL_Issue32_StoreSettingsCheck validates the exact SQL from issue #32.
+func TestAnalyzeSQL_DDL_Issue32_StoreSettingsCheck(t *testing.T) {
+	sql := `CREATE TABLE public.store_settings (
+    id boolean DEFAULT true NOT NULL,
+    active_languages text[] NOT NULL,
+    default_language text NOT NULL,
+    max_players_per_team integer NOT NULL,
+    timezone text NOT NULL,
+    CONSTRAINT store_settings_check CHECK ((default_language = ANY (active_languages))),
+    CONSTRAINT store_settings_id_check CHECK ((id = true))
+);`
+
+	res, err := AnalyzeSQL(sql)
+	require.NoError(t, err)
+
+	assert.Equal(t, SQLCommandDDL, res.Command)
+	require.Len(t, res.DDLActions, 1)
+	act := res.DDLActions[0]
+
+	assert.Equal(t, string(postgresparser.DDLCreateTable), act.Type)
+	assert.Equal(t, "store_settings", act.ObjectName)
+	assert.Equal(t, "public", act.Schema)
+
+	// Verify columns
+	require.Len(t, act.ColumnDetails, 5)
+	assert.Equal(t, "id", act.ColumnDetails[0].Name)
+	assert.Equal(t, "boolean", act.ColumnDetails[0].Type)
+	assert.Equal(t, false, act.ColumnDetails[0].Nullable)
+	assert.Equal(t, "true", act.ColumnDetails[0].Default)
+	assert.Equal(t, "text[]", act.ColumnDetails[1].Type)
+
+	// Verify both CHECK constraints
+	require.NotNil(t, act.Constraints)
+	require.Len(t, act.Constraints.CheckConstraints, 2)
+
+	assert.Equal(t, "store_settings_check", act.Constraints.CheckConstraints[0].ConstraintName)
+	assert.Equal(t, "(default_language = ANY (active_languages))", act.Constraints.CheckConstraints[0].Expression)
+
+	assert.Equal(t, "store_settings_id_check", act.Constraints.CheckConstraints[1].ConstraintName)
+	assert.Equal(t, "(id = true)", act.Constraints.CheckConstraints[1].Expression)
 }
 
 func assertAnalysisFlag(t *testing.T, flags []string, flag string) {

--- a/docs/parsed-query.md
+++ b/docs/parsed-query.md
@@ -88,7 +88,7 @@ Common DDL action fields:
 - `Flags`: Modifiers like `IF_EXISTS`, `IF_NOT_EXISTS`, `CASCADE`, `CONCURRENTLY`, etc.
 - `IndexType`: Index method for `CREATE_INDEX` (for example `btree`, `gin`).
 - `ColumnDetails`: Column metadata for `CREATE_TABLE` actions.
-- `Constraints`: Optional `*DDLConstraints` grouping PK/FK/UNIQUE metadata (`CREATE_TABLE`, `ALTER_TABLE ADD CONSTRAINT`).
+- `Constraints`: Optional `*DDLConstraints` grouping PK/FK/UNIQUE/CHECK metadata (`CREATE_TABLE`, `ALTER_TABLE ADD CONSTRAINT`).
 - `Target`: Generic fully-qualified target path for comment-like actions (for example `public.users.email`).
 - `Comment`: Comment text for `COMMENT` actions.
 
@@ -103,6 +103,7 @@ Common DDL action fields:
 - `PrimaryKey` (`*DDLPrimaryKey`): `ConstraintName` (optional), `Columns`.
 - `ForeignKeys` (`[]DDLForeignKey`): `ConstraintName` (optional), `Columns`, `ReferencesSchema` (optional), `ReferencesTable`, `ReferencesColumns` (optional), `OnDelete` (optional), `OnUpdate` (optional). Referential actions: `CASCADE`, `SET NULL`, `SET DEFAULT`, `RESTRICT`, `NO ACTION`.
 - `UniqueKeys` (`[]DDLUniqueConstraint`): `ConstraintName` (optional), `Columns`.
+- `CheckConstraints` (`[]DDLCheckConstraint`): `ConstraintName` (optional), `Expression`.
 
 Current DDL convention:
 - `CREATE_TABLE` populates `ColumnDetails` and `Constraints` for inline and table-level constraints.

--- a/docs/supported-statements.md
+++ b/docs/supported-statements.md
@@ -20,8 +20,8 @@ These statements are walked via ANTLR visitors and produce rich IR metadata in `
 | `UPDATE` | `UPDATE` | `Tables`, `SetClauses`, `Where`, `Returning`, `CTEs`, `ColumnUsage` |
 | `DELETE` | `DELETE` | `Tables`, `Where`, `Returning`, `CTEs`, `ColumnUsage` |
 | `MERGE` | `MERGE` | `Tables`, `Merge` (target, source, condition, actions) |
-| `CREATE TABLE` | `DDL` | `Tables`, `DDLActions` (with `ColumnDetails`, `Constraints`) |
-| `ALTER TABLE` | `DDL` | `Tables`, `DDLActions` (including `Constraints` on `ADD CONSTRAINT`) |
+| `CREATE TABLE` | `DDL` | `Tables`, `DDLActions` (with `ColumnDetails`, `Constraints`: PK/FK/UNIQUE/CHECK) |
+| `ALTER TABLE` | `DDL` | `Tables`, `DDLActions` (including `Constraints` on `ADD CONSTRAINT`: PK/FK/UNIQUE/CHECK) |
 | `DROP TABLE` / `DROP INDEX` | `DDL` | `DDLActions` (with `Flags`) |
 | `CREATE INDEX` | `DDL` | `DDLActions` (with `IndexType`) |
 | `TRUNCATE` | `DDL` | `Tables`, `DDLActions` |

--- a/examples/ddl/main.go
+++ b/examples/ddl/main.go
@@ -15,10 +15,20 @@ func main() {
     name text,
     created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
 );`
+	createWithChecks := `CREATE TABLE public.store_settings (
+    id boolean DEFAULT true NOT NULL,
+    active_languages text[] NOT NULL,
+    default_language text NOT NULL,
+    max_players_per_team integer NOT NULL,
+    timezone text NOT NULL,
+    CONSTRAINT store_settings_check CHECK ((default_language = ANY (active_languages))),
+    CONSTRAINT store_settings_id_check CHECK ((id = true))
+);`
 	alterSQL := `ALTER TABLE public.users ADD COLUMN status text`
 	deleteSQL := `DELETE FROM public.users WHERE id = 42`
 
 	printParsed("CREATE TABLE", createSQL)
+	printParsed("CREATE TABLE WITH CHECK", createWithChecks)
 	printParsed("ALTER TABLE", alterSQL)
 	printParsed("DELETE", deleteSQL)
 }
@@ -40,6 +50,11 @@ func printParsed(label, sql string) {
 		}
 		for _, col := range action.ColumnDetails {
 			fmt.Printf("  - %s %s nullable=%t default=%q\n", col.Name, col.Type, col.Nullable, col.Default)
+		}
+		if action.Constraints != nil {
+			for _, chk := range action.Constraints.CheckConstraints {
+				fmt.Printf("  CHECK %q: %s\n", chk.ConstraintName, chk.Expression)
+			}
 		}
 	}
 	if len(result.Where) > 0 {

--- a/parser_ir_ddl_test.go
+++ b/parser_ir_ddl_test.go
@@ -1497,6 +1497,41 @@ func TestIR_DDL_CreateTableWithCheckConstraint(t *testing.T) {
 			);`,
 			wantChecks: 2,
 		},
+		{
+			name: "issue #32 — pg_dump style with ANY()",
+			sql: `CREATE TABLE public.store_settings (
+				id boolean DEFAULT true NOT NULL,
+				active_languages text[] NOT NULL,
+				default_language text NOT NULL,
+				max_players_per_team integer NOT NULL,
+				timezone text NOT NULL,
+				CONSTRAINT store_settings_check CHECK ((default_language = ANY (active_languages))),
+				CONSTRAINT store_settings_id_check CHECK ((id = true))
+			);`,
+			wantChecks:     2,
+			wantConstraint: "store_settings_check",
+			wantExpr:       "(default_language = ANY (active_languages))",
+		},
+		{
+			name: "CHECK with boolean expression and nested parens",
+			sql: `CREATE TABLE public.events (
+				start_date date NOT NULL,
+				end_date date NOT NULL,
+				CONSTRAINT valid_dates CHECK ((end_date > start_date))
+			);`,
+			wantChecks:     1,
+			wantConstraint: "valid_dates",
+			wantExpr:       "(end_date > start_date)",
+		},
+		{
+			name: "CHECK with OR and function call",
+			sql: `CREATE TABLE public.users (
+				email text NOT NULL,
+				CONSTRAINT valid_email CHECK ((email ~~ '%@%'::text) OR (length(email) > 5))
+			);`,
+			wantChecks:     1,
+			wantConstraint: "valid_email",
+		},
 	}
 
 	for _, tc := range tests {
@@ -1519,4 +1554,45 @@ func TestIR_DDL_CreateTableWithCheckConstraint(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestIR_DDL_Issue32_StoreSettingsCheck validates the exact SQL from issue #32.
+func TestIR_DDL_Issue32_StoreSettingsCheck(t *testing.T) {
+	sql := `CREATE TABLE public.store_settings (
+    id boolean DEFAULT true NOT NULL,
+    active_languages text[] NOT NULL,
+    default_language text NOT NULL,
+    max_players_per_team integer NOT NULL,
+    timezone text NOT NULL,
+    CONSTRAINT store_settings_check CHECK ((default_language = ANY (active_languages))),
+    CONSTRAINT store_settings_id_check CHECK ((id = true))
+);`
+
+	ir := parseAssertNoError(t, sql)
+
+	assert.Equal(t, QueryCommandDDL, ir.Command)
+	require.Len(t, ir.DDLActions, 1)
+	act := ir.DDLActions[0]
+
+	assert.Equal(t, DDLCreateTable, act.Type)
+	assert.Equal(t, "store_settings", act.ObjectName)
+	assert.Equal(t, "public", act.Schema)
+
+	// Verify columns
+	require.Len(t, act.ColumnDetails, 5)
+	assert.Equal(t, "id", act.ColumnDetails[0].Name)
+	assert.Equal(t, "boolean", act.ColumnDetails[0].Type)
+	assert.Equal(t, false, act.ColumnDetails[0].Nullable)
+	assert.Equal(t, "true", act.ColumnDetails[0].Default)
+	assert.Equal(t, "text[]", act.ColumnDetails[1].Type)
+
+	// Verify both CHECK constraints
+	require.NotNil(t, act.Constraints)
+	require.Len(t, act.Constraints.CheckConstraints, 2)
+
+	assert.Equal(t, "store_settings_check", act.Constraints.CheckConstraints[0].ConstraintName)
+	assert.Equal(t, "(default_language = ANY (active_languages))", act.Constraints.CheckConstraints[0].Expression)
+
+	assert.Equal(t, "store_settings_id_check", act.Constraints.CheckConstraints[1].ConstraintName)
+	assert.Equal(t, "(id = true)", act.Constraints.CheckConstraints[1].Expression)
 }


### PR DESCRIPTION
## Summary

  - Add test coverage for CHECK constraints using the exact SQL from issue #32 (pg_dump style with `ANY()`, nested parens, OR with function calls)
  - Document CHECK constraint support across README, parsed-query reference, and supported-statements guide
  - Add CHECK constraint output to the DDL example

  ## Layer

  - [ ] Core parser (`ir.go`, `ddl.go`, `select.go`, `dml_*.go`, `merge.go`, `setops.go`, `entry.go`)
  - [x] Analysis layer (`analysis/`)
  - [x] Docs / examples
  - [ ] CI / tooling

  ## SQL examples

  ```sql
  CREATE TABLE public.store_settings (
      id boolean DEFAULT true NOT NULL,
      active_languages text[] NOT NULL,
      default_language text NOT NULL,
      max_players_per_team integer NOT NULL,
      timezone text NOT NULL,
      CONSTRAINT store_settings_check CHECK ((default_language = ANY (active_languages))),
      CONSTRAINT store_settings_id_check CHECK ((id = true))
  );
 ```
  Output:
 ```
  "CheckConstraints": [
    {
      "ConstraintName": "store_settings_check",
      "Expression": "(default_language = ANY (active_languages))"
    },
    {
      "ConstraintName": "store_settings_id_check",
      "Expression": "(id = true)"
    }
  ]
 ```
  Test plan

  - New unit tests added
  - Existing tests updated
  - make test passes (race detector + coverage)
  - make vet passes
  - Manual verification with examples/

  Related issues

  Closes #32

  Checklist

  - No changes to gen/ (auto-generated ANTLR code)
  - New IR fields documented in docs/parsed-query.md (if applicable)
  - Public API additions are backward compatible