### PR TITLE
feat(cte): add parsed query for CTE bodies

### DIFF
--- a/analysis/analysis.go
+++ b/analysis/analysis.go
@@ -243,6 +243,7 @@ func convertCTEs(ctes []postgresparser.CTE) []SQLCTE {
 		out = append(out, SQLCTE{
 			Name:         cte.Name,
 			Query:        cte.Query,
+			Analysis:     convertParsedQuery(cte.ParsedQuery),
 			Materialized: cte.Materialized,
 		})
 	}

--- a/analysis/cte_analysis_test.go
+++ b/analysis/cte_analysis_test.go
@@ -1,0 +1,42 @@
+package analysis
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAnalyzeSQL_CTEAnalysis(t *testing.T) {
+	sql := `WITH active_users AS (
+    SELECT users.id, users.name FROM users WHERE users.active = $1
+)
+SELECT active_users.id, active_users.name
+FROM active_users
+WHERE active_users.id = $2`
+
+	result, err := AnalyzeSQL(sql)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, result.CTEs, 1)
+
+	cte := result.CTEs[0]
+	require.NotNil(t, cte.Analysis)
+	assert.Equal(t, SQLCommandSelect, cte.Analysis.Command)
+	assert.Equal(t, cte.Query, cte.Analysis.RawSQL)
+	require.Len(t, cte.Analysis.Columns, 2)
+	assert.Equal(t, "users.id", cte.Analysis.Columns[0].Expression)
+	assert.Equal(t, "users.name", cte.Analysis.Columns[1].Expression)
+
+	require.Len(t, cte.Analysis.Parameters, 1)
+	assert.Equal(t, "$1", cte.Analysis.Parameters[0].Raw)
+
+	var foundUsers bool
+	for _, table := range cte.Analysis.Tables {
+		if table.Name == "users" {
+			foundUsers = true
+			break
+		}
+	}
+	assert.True(t, foundUsers, "expected nested CTE analysis to include users table")
+}

--- a/analysis/types.go
+++ b/analysis/types.go
@@ -96,6 +96,7 @@ type SQLSubquery struct {
 type SQLCTE struct {
 	Name         string
 	Query        string
+	Analysis     *SQLAnalysis
 	Materialized string
 }
 

--- a/docs/parsed-query.md
+++ b/docs/parsed-query.md
@@ -51,6 +51,10 @@ It is not designed for:
 
 - `Tables`: Structured relation refs (`Schema`, `Name`, `Alias`, `Type`, `Raw`).
 - `CTEs`: `WITH` definitions.
+  - `Name`: CTE binding name.
+  - `Query`: raw SQL text of the CTE body.
+  - `ParsedQuery`: nested IR for the CTE body when the body is a supported preparable statement.
+  - `Materialized`: materialization hint (`MATERIALIZED`, `NOT MATERIALIZED`, or empty).
 - `Subqueries`: Nested query refs discovered in the statement.
 - `JoinConditions`: Raw join condition expressions.
 - `Correlations`: Outer/inner alias correlation metadata for lateral/correlated subqueries.

--- a/entry.go
+++ b/entry.go
@@ -174,11 +174,7 @@ func prepareParseState(sql string, tolerateSyntaxErrors bool) (*parseState, erro
 
 // parseStatementToIR maps a single parsed statement node to ParsedQuery IR.
 func parseStatementToIR(stmt gen.IStmtContext, stream antlr.TokenStream, rawSQL string, opts ParseOptions) (*ParsedQuery, error) {
-	res := &ParsedQuery{
-		Command:        QueryCommandUnknown,
-		RawSQL:         strings.TrimSpace(rawSQL),
-		DerivedColumns: make(map[string]string),
-	}
+	res := newParsedQuery(rawSQL)
 
 	switch {
 	case stmt.Selectstmt() != nil:
@@ -242,6 +238,50 @@ func parseStatementToIR(stmt gen.IStmtContext, stream antlr.TokenStream, rawSQL 
 
 	res.Parameters = extractParameters(rawSQL)
 	return res, nil
+}
+
+func parsePreparableStmtToIR(stmt gen.IPreparablestmtContext, stream antlr.TokenStream, rawSQL string, _ ParseOptions) (*ParsedQuery, error) {
+	if stmt == nil {
+		return nil, fmt.Errorf("preparable statement: %w", ErrNilContext)
+	}
+
+	res := newParsedQuery(rawSQL)
+
+	switch {
+	case stmt.Selectstmt() != nil:
+		res.Command = QueryCommandSelect
+		if err := populateSelect(res, stmt.Selectstmt(), stream); err != nil {
+			return nil, err
+		}
+	case stmt.Insertstmt() != nil:
+		res.Command = QueryCommandInsert
+		if err := populateInsert(res, stmt.Insertstmt(), stream); err != nil {
+			return nil, err
+		}
+	case stmt.Updatestmt() != nil:
+		res.Command = QueryCommandUpdate
+		if err := populateUpdate(res, stmt.Updatestmt(), stream); err != nil {
+			return nil, err
+		}
+	case stmt.Deletestmt() != nil:
+		res.Command = QueryCommandDelete
+		if err := populateDelete(res, stmt.Deletestmt(), stream); err != nil {
+			return nil, err
+		}
+	default:
+		return res, nil
+	}
+
+	res.Parameters = extractParameters(rawSQL)
+	return res, nil
+}
+
+func newParsedQuery(rawSQL string) *ParsedQuery {
+	return &ParsedQuery{
+		Command:        QueryCommandUnknown,
+		RawSQL:         strings.TrimSpace(rawSQL),
+		DerivedColumns: make(map[string]string),
+	}
 }
 
 // statementText extracts the exact SQL text for one statement node.

--- a/entry.go
+++ b/entry.go
@@ -240,6 +240,8 @@ func parseStatementToIR(stmt gen.IStmtContext, stream antlr.TokenStream, rawSQL 
 	return res, nil
 }
 
+// parsePreparableStmtToIR converts a CTE/body preparable statement into nested
+// ParsedQuery IR while preserving the raw SQL text for the body.
 func parsePreparableStmtToIR(stmt gen.IPreparablestmtContext, stream antlr.TokenStream, rawSQL string, _ ParseOptions) (*ParsedQuery, error) {
 	if stmt == nil {
 		return nil, fmt.Errorf("preparable statement: %w", ErrNilContext)

--- a/ir.go
+++ b/ir.go
@@ -233,6 +233,7 @@ type Parameter struct {
 type CTE struct {
 	Name         string
 	Query        string
+	ParsedQuery  *ParsedQuery
 	Materialized string // "", "MATERIALIZED", or "NOT MATERIALIZED"
 }
 

--- a/parser_ir_cte_parsed_query_test.go
+++ b/parser_ir_cte_parsed_query_test.go
@@ -1,0 +1,61 @@
+package postgresparser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIR_CTEParsedQuery_Select(t *testing.T) {
+	sql := `WITH active_users AS (
+    SELECT users.id, users.name FROM users WHERE users.active = $1
+)
+SELECT active_users.id, active_users.name
+FROM active_users
+WHERE active_users.id = $2`
+
+	ir := parseAssertNoError(t, sql)
+	require.Len(t, ir.CTEs, 1)
+
+	cte := ir.CTEs[0]
+	require.NotNil(t, cte.ParsedQuery)
+	assert.Equal(t, QueryCommandSelect, cte.ParsedQuery.Command)
+	assert.Equal(t, cte.Query, cte.ParsedQuery.RawSQL)
+
+	require.Len(t, cte.ParsedQuery.Columns, 2)
+	assert.Equal(t, "users.id", cte.ParsedQuery.Columns[0].Expression)
+	assert.Equal(t, "users.name", cte.ParsedQuery.Columns[1].Expression)
+	assert.True(t, containsTable(cte.ParsedQuery.Tables, "users"))
+
+	require.Len(t, cte.ParsedQuery.Parameters, 1)
+	assert.Equal(t, "$1", cte.ParsedQuery.Parameters[0].Raw)
+
+	var foundFilter bool
+	for _, usage := range cte.ParsedQuery.ColumnUsage {
+		if usage.UsageType == ColumnUsageTypeFilter && usage.Column == "active" {
+			foundFilter = true
+			break
+		}
+	}
+	assert.True(t, foundFilter, "expected CTE parsed query to retain filter column usage")
+}
+
+func TestIR_CTEParsedQuery_Update(t *testing.T) {
+	sql := `WITH updated_users AS (
+    UPDATE users SET active = true WHERE id = $1 RETURNING id
+)
+SELECT * FROM updated_users`
+
+	ir := parseAssertNoError(t, sql)
+	require.Len(t, ir.CTEs, 1)
+
+	cte := ir.CTEs[0]
+	require.NotNil(t, cte.ParsedQuery)
+	assert.Equal(t, QueryCommandUpdate, cte.ParsedQuery.Command)
+	assert.True(t, containsTable(cte.ParsedQuery.Tables, "users"))
+	assert.NotEmpty(t, cte.ParsedQuery.SetClauses)
+	assert.NotEmpty(t, cte.ParsedQuery.Returning)
+	require.Len(t, cte.ParsedQuery.Parameters, 1)
+	assert.Equal(t, "$1", cte.ParsedQuery.Parameters[0].Raw)
+}

--- a/select.go
+++ b/select.go
@@ -128,7 +128,7 @@ func resolveSelectFromParens(swp gen.ISelect_with_parensContext) (gen.IWith_clau
 }
 
 // extractCTEs captures metadata for each common table expression defined in WITH.
-// It also recursively parses the CTE queries to extract tables referenced within them.
+// It also builds nested IR for the CTE body and surfaces tables referenced within it.
 func extractCTEs(withCtx gen.IWith_clauseContext, tokens antlr.TokenStream) ([]CTE, []TableRef) {
 	if withCtx == nil {
 		return nil, nil
@@ -158,15 +158,20 @@ func extractCTEs(withCtx gen.IWith_clauseContext, tokens antlr.TokenStream) ([]C
 			}
 		}
 		query := ""
+		var parsedQuery *ParsedQuery
 		if cteCtx.Preparablestmt() != nil {
 			if prc, ok := cteCtx.Preparablestmt().(antlr.ParserRuleContext); ok {
 				query = strings.TrimSpace(ctxText(tokens, prc))
 			}
 
-			// Recursively parse the CTE's query to extract tables
 			if stmtCtx := cteCtx.Preparablestmt(); stmtCtx != nil {
-				// Try to extract tables from the CTE's statement
-				if tables := extractTablesFromPreparableStmt(stmtCtx, tokens); len(tables) > 0 {
+				parsed, err := parsePreparableStmtToIR(stmtCtx, tokens, query, ParseOptions{})
+				if err == nil {
+					parsedQuery = parsed
+					if tables := extractTablesFromParsedQuery(parsedQuery); len(tables) > 0 {
+						allTables = append(allTables, tables...)
+					}
+				} else if tables := extractTablesFromPreparableStmt(stmtCtx, tokens); len(tables) > 0 {
 					allTables = append(allTables, tables...)
 				}
 			}
@@ -177,6 +182,7 @@ func extractCTEs(withCtx gen.IWith_clauseContext, tokens antlr.TokenStream) ([]C
 		ctes = append(ctes, CTE{
 			Name:         name,
 			Query:        query,
+			ParsedQuery:  parsedQuery,
 			Materialized: materialized,
 		})
 	}
@@ -190,69 +196,29 @@ func extractTablesFromPreparableStmt(stmt gen.IPreparablestmtContext, tokens ant
 		return nil
 	}
 
-	var tables []TableRef
+	rawSQL := ""
+	if prc, ok := stmt.(antlr.ParserRuleContext); ok {
+		rawSQL = strings.TrimSpace(ctxText(tokens, prc))
+	}
 
-	// Check if it's a SELECT statement
-	if selectCtx := stmt.Selectstmt(); selectCtx != nil {
-		// Create a temporary result to collect tables
-		tempResult := &ParsedQuery{}
+	parsed, err := parsePreparableStmtToIR(stmt, tokens, rawSQL, ParseOptions{})
+	if err != nil {
+		return nil
+	}
+	return extractTablesFromParsedQuery(parsed)
+}
 
-		// Resolve the SELECT statement
-		withClause, simpleSelect, selectNoParens, err := resolveSelect(selectCtx)
-		if err == nil && simpleSelect != nil {
-			// Build a map of CTE names (empty for nested parsing)
-			cteNames := map[string]struct{}{}
+func extractTablesFromParsedQuery(parsed *ParsedQuery) []TableRef {
+	if parsed == nil {
+		return nil
+	}
 
-			// If this nested statement has its own WITH clause, handle it recursively
-			if withClause != nil {
-				nestedCTEs, nestedTables := extractCTEs(withClause, tokens)
-				if len(nestedCTEs) > 0 {
-					for _, cte := range nestedCTEs {
-						if cte.Name != "" {
-							cteNames[strings.ToLower(cte.Name)] = struct{}{}
-						}
-					}
-				}
-				if len(nestedTables) > 0 {
-					tables = append(tables, nestedTables...)
-				}
-			}
-
-			// Extract tables from the FROM clause
-			extractFromClause(tempResult, simpleSelect.From_clause(), tokens, cteNames)
-
-			// Extract tables from subqueries in WHERE, HAVING, etc.
-			if simpleSelect.Where_clause() != nil {
-				extractWhereClause(tempResult, simpleSelect.Where_clause(), tokens)
-			}
-
-			// Collect all base tables (not CTEs)
-			tables = append(tables, tempResult.Tables...)
-
-			// Also handle any subqueries
-			for _, subq := range tempResult.Subqueries {
-				if subq.Query != nil {
-					tables = append(tables, subq.Query.Tables...)
-				}
-			}
-
-			// Handle set operations if present
-			if selectNoParens != nil {
-				setOps, leadingTables, _ := extractSetOperationsWithResult(selectNoParens, tokens, cteNames, tempResult)
-				if len(leadingTables) > 0 {
-					tables = append(tables, leadingTables...)
-				}
-				// Add tables from set operations
-				for _, setOp := range setOps {
-					if len(setOp.Tables) > 0 {
-						tables = append(tables, setOp.Tables...)
-					}
-				}
-			}
+	tables := append([]TableRef(nil), parsed.Tables...)
+	for _, subq := range parsed.Subqueries {
+		if subq.Query != nil {
+			tables = append(tables, extractTablesFromParsedQuery(subq.Query)...)
 		}
 	}
-	// Other statement types (INSERT, UPDATE, DELETE) could be handled here if needed
-
 	return tables
 }
 


### PR DESCRIPTION
## Summary

- Add nested parsed IR for each CTE body while keeping `CTE.Query` as the existing raw SQL string.
- Expose the same nested CTE information in the analysis layer via `SQLCTE.Analysis`.
- Reuse the nested CTE IR for table extraction, add regression coverage, and document the new IR field.

## Layer

<!-- Which layer does this change touch? Check all that apply. -->

- [x] Core parser (`ir.go`, `ddl.go`, `select.go`, `dml_*.go`, `merge.go`, `setops.go`, `entry.go`)
- [x] Analysis layer (`analysis/`)
- [x] Docs / examples
- [ ] CI / tooling

## SQL examples

<!-- Show at least one SQL statement this PR affects, with before/after output if applicable. -->

```sql
WITH active_users AS (
    SELECT users.id, users.name FROM users WHERE users.active = $1
)
SELECT active_users.id, active_users.name
FROM active_users
WHERE active_users.id = $2;

-- Before:
-- CTEs[0].Query was only the raw SQL string for the CTE body.

-- After:
-- CTEs[0].Query remains the raw SQL string.
-- CTEs[0].ParsedQuery contains nested IR for the CTE body.
-- In analysis, CTEs[0].Analysis contains the nested SQLAnalysis.
```

## Test plan

<!-- How was this tested? Check all that apply. -->

- [x] New unit tests added
- [ ] Existing tests updated
- [ ] `make test` passes (race detector + coverage)
- [x] `make vet` passes
- [ ] Manual verification with `examples/`

Additional verification:
- `go test ./...` passes
- `go vet $(go list ./... | grep -Ev '/(gen|examples)(/|$)')` passes
- `go test -count=1 $(go list ./... | grep -Ev '/(gen|examples)(/|$)')` passes

Note: local `make test` currently fails in `examples/*` with `go: no such tool "covdata"`; CI does not use that exact package selection.

## Related issues

Fixes #47

## Checklist

- [x] No changes to `gen/` (auto-generated ANTLR code)
- [x] New IR fields documented in `docs/parsed-query.md` (if applicable)
- [x] Public API additions are backward compatible