### PR TITLE
tooling: add make race target for standalone race detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all test vet lint help
+.PHONY: all test vet lint race help
 
 all: vet test lint
 
@@ -8,6 +8,9 @@ test:
 vet:
 	go vet $$(go list ./... | grep -v /gen)
 
+race:
+	go test -v -race -count=1 $$(go list ./... | grep -v /gen)
+
 lint:
 	if command -v golangci-lint >/dev/null; then golangci-lint run; else echo "golangci-lint not found"; fi
 
@@ -15,5 +18,6 @@ help:
 	@echo "Available targets:"
 	@echo "  test  - Run tests with race detector and coverage"
 	@echo "  vet   - Run go vet excluding generated code"
+	@echo "  race  - Run tests with race detector (no coverage overhead)"
 	@echo "  lint  - Run golangci-lint"
 	@echo "  all   - Run vet, test, and lint"


### PR DESCRIPTION
## Summary

- Added a standalone `make race` target that runs tests with the Go race detector without coverage overhead
- The `make vet` target already exists in the Makefile, so no changes needed there

## Layer

- [x] CI / tooling

## SQL examples

```sql
-- N/A (tooling-only change, no parser behavior affected)
```

## Test plan

- [x] `make race` passes
- [x] `make vet` passes
- [x] `make test` passes

## Related issues

Fixes #62

## Checklist

- [x] No changes to `gen/` (auto-generated ANTLR code)
- [x] N/A (no new IR fields)
- [x] N/A (no public API changes)
