### PR TITLE
refactor(select): merge populateSelectFromResolved and its nested variant

### DIFF
--- a/parser_ir_setops_test.go
+++ b/parser_ir_setops_test.go
@@ -108,3 +108,35 @@ SELECT user_id FROM revoked_permissions`,
 		})
 	}
 }
+
+// TestIR_SetOpBranchLimitIsNested guards the isNested flag propagation through
+// the consolidated populateSelectFromResolved entry-point: a LIMIT on the
+// top-level select must report IsNested=false, while a LIMIT inside a
+// set-operation branch must report IsNested=true.
+func TestIR_SetOpBranchLimitIsNested(t *testing.T) {
+	sql := `
+(SELECT id FROM a)
+UNION ALL
+(SELECT id FROM b LIMIT 5)
+LIMIT 10`
+
+	ir := parseAssertNoError(t, sql)
+
+	require.NotNil(t, ir.Limit, "expected top-level LIMIT")
+	assert.Contains(t, ir.Limit.Limit, "10", "unexpected top-level LIMIT value")
+	assert.False(t, ir.Limit.IsNested, "expected IsNested=false on top-level LIMIT")
+
+	require.Len(t, ir.SetOperations, 1, "expected one set operation")
+	require.NotEmpty(t, ir.Subqueries, "expected set-op branch captured as subquery")
+
+	var branch *ParsedQuery
+	for _, sq := range ir.Subqueries {
+		if sq.Query != nil && sq.Query.Limit != nil {
+			branch = sq.Query
+			break
+		}
+	}
+	require.NotNil(t, branch, "expected a set-op branch ParsedQuery with a LIMIT")
+	assert.Contains(t, branch.Limit.Limit, "5", "unexpected branch LIMIT value")
+	assert.True(t, branch.Limit.IsNested, "expected IsNested=true on set-op branch LIMIT")
+}

--- a/select.go
+++ b/select.go
@@ -17,17 +17,14 @@ func populateSelect(result *ParsedQuery, selectCtx gen.ISelectstmtContext, token
 	if err != nil {
 		return err
 	}
-	return populateSelectFromResolved(result, withClause, simple, selectNoParens, tokens)
+	return populateSelectFromResolved(result, withClause, simple, selectNoParens, tokens, false)
 }
 
 // populateSelectFromResolved fills the ParsedQuery using pre-resolved SELECT components.
+// Pass isNested=true when populating a subquery (e.g. a set-operation branch);
+// the flag is recorded on LimitClause.IsNested so callers can distinguish
+// branch-local LIMITs from a top-level LIMIT.
 func populateSelectFromResolved(result *ParsedQuery, withClause gen.IWith_clauseContext, simple gen.ISimple_select_pramaryContext,
-	selectNoParens gen.ISelect_no_parensContext, tokens antlr.TokenStream) error {
-	return populateSelectFromResolvedNested(result, withClause, simple, selectNoParens, tokens, false)
-}
-
-// populateSelectFromResolvedNested fills the ParsedQuery with nesting awareness.
-func populateSelectFromResolvedNested(result *ParsedQuery, withClause gen.IWith_clauseContext, simple gen.ISimple_select_pramaryContext,
 	selectNoParens gen.ISelect_no_parensContext, tokens antlr.TokenStream, isNested bool) error {
 	if result == nil {
 		return fmt.Errorf("select result container: %w", ErrNilContext)

--- a/setops.go
+++ b/setops.go
@@ -330,7 +330,7 @@ func buildSubqueryRef(alias string, selectWithParens gen.ISelect_with_parensCont
 		RawSQL:         rawSQL,
 		DerivedColumns: make(map[string]string),
 	}
-	if err := populateSelectFromResolvedNested(parsed, withClause, simple, selectNoParens, tokens, true); err != nil {
+	if err := populateSelectFromResolved(parsed, withClause, simple, selectNoParens, tokens, true); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
## Summary

- Drop the delegating shim `populateSelectFromResolved(...)` that just called the nested variant with `isNested=false`.
- Rename `populateSelectFromResolvedNested` → `populateSelectFromResolved` (the nested form is now the canonical entry-point).
- Update the two internal call sites to pass `false` / `true` directly.

## Layer

- [x] Core parser (`select.go`, `setops.go`)

## SQL examples

```sql
-- N/A — internal refactor of two unexported helpers, no parser behavior affected.
```

## Test plan

- [x] New unit test added (`TestIR_SetOpBranchLimitIsNested`) guarding `isNested` propagation through the consolidated entry-point: top-level `LIMIT` reports `IsNested=false`, set-op-branch `LIMIT` reports `IsNested=true`.
- [x] `go test -race ./...` passes
- [x] `golangci-lint run ./...` — 0 issues

## Behavioral impact

Zero. Both functions are unexported, so the rename has no external API impact. The pre-change top-level path went `populateSelect → populateSelectFromResolved (wrapper, hardcoded false) → populateSelectFromResolvedNested(...,false)`; post-change it's `populateSelect → populateSelectFromResolved(...,false)`. Same boolean reaches `extractLimitClause`. The set-op path was already passing `true` to the nested form and continues to.

## Related issues

Closes #61

## Checklist

- [x] No changes to `gen/` (auto-generated ANTLR code)
- [x] N/A (no new IR fields)
- [x] N/A (no public API changes — both functions are unexported)