### PR TITLE
fix(select): detect LATERAL via grammar terminal, not substring scan

### DIFF
--- a/parser_ir_select_test.go
+++ b/parser_ir_select_test.go
@@ -494,3 +494,69 @@ func TestContainsWordDot(t *testing.T) {
 		assert.Equal(t, tt.want, got, "containsWordDot(%q, %q)", tt.text, tt.word)
 	}
 }
+
+// TestIR_LateralDetection_GrammarDriven validates that LATERAL detection is
+// driven by the grammar's LATERAL_P terminal, not a substring scan of the
+// rendered text.
+//
+// Positive cases: actual LATERAL keyword must continue to populate
+// Correlations when it correlates to an outer alias via the function text.
+//
+// Negative cases: identifiers whose names contain the substring "lateral"
+// (table, column, alias, string-literal, comment) must NOT trigger detection.
+func TestIR_LateralDetection_GrammarDriven(t *testing.T) {
+	t.Run("positive_cross_join_lateral_func_with_outer_correlation", func(t *testing.T) {
+		// CROSS JOIN LATERAL <func>(c.alias_ref) — outer alias `c` referenced.
+		sql := `SELECT * FROM customers c CROSS JOIN LATERAL generate_series(1, c.id) AS gs`
+		ir := parseAssertNoError(t, sql)
+
+		var found bool
+		for _, corr := range ir.Correlations {
+			if corr.Type == "LATERAL" && corr.OuterAlias == "c" {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, "expected LATERAL correlation for outer alias 'c', got %+v", ir.Correlations)
+	})
+
+	t.Run("negative_table_name_contains_lateral_substring", func(t *testing.T) {
+		// `bilateral_offsets` contains "lateral" as a substring but the query
+		// has no LATERAL keyword anywhere. detectLateralCorrelation must not run.
+		sql := `SELECT * FROM bilateral_offsets bo
+			CROSS JOIN generate_series(1, 10) AS gs`
+		ir := parseAssertNoError(t, sql)
+
+		assert.Empty(t, ir.Correlations,
+			"no LATERAL keyword present; substring 'lateral' in table name must not trigger detection: %+v", ir.Correlations)
+	})
+
+	t.Run("negative_column_name_contains_lateral_substring", func(t *testing.T) {
+		sql := `SELECT lateral_value FROM metrics
+			CROSS JOIN generate_series(1, 10) AS gs`
+		ir := parseAssertNoError(t, sql)
+
+		assert.Empty(t, ir.Correlations,
+			"no LATERAL keyword present; substring 'lateral' in column name must not trigger detection: %+v", ir.Correlations)
+	})
+
+	t.Run("negative_string_literal_contains_lateral", func(t *testing.T) {
+		sql := `SELECT * FROM t
+			CROSS JOIN generate_series(1, 10) AS gs
+			WHERE notes = 'lateral metric notes'`
+		ir := parseAssertNoError(t, sql)
+
+		assert.Empty(t, ir.Correlations,
+			"no LATERAL keyword present; substring 'lateral' inside string literal must not trigger detection: %+v", ir.Correlations)
+	})
+
+	t.Run("negative_alias_contains_lateral_substring", func(t *testing.T) {
+		// Alias `lateral_alias` contains "lateral" as a substring; no LATERAL keyword.
+		sql := `SELECT * FROM events lateral_alias
+			CROSS JOIN generate_series(1, 10) AS gs`
+		ir := parseAssertNoError(t, sql)
+
+		assert.Empty(t, ir.Correlations,
+			"no LATERAL keyword present; substring 'lateral' in alias must not trigger detection: %+v", ir.Correlations)
+	})
+}

--- a/parser_ir_select_test.go
+++ b/parser_ir_select_test.go
@@ -495,15 +495,6 @@ func TestContainsWordDot(t *testing.T) {
 	}
 }
 
-// TestIR_LateralDetection_GrammarDriven validates that LATERAL detection is
-// driven by the grammar's LATERAL_P terminal, not a substring scan of the
-// rendered text.
-//
-// Positive cases: actual LATERAL keyword must continue to populate
-// Correlations when it correlates to an outer alias via the function text.
-//
-// Negative cases: identifiers whose names contain the substring "lateral"
-// (table, column, alias, string-literal, comment) must NOT trigger detection.
 func TestIR_LateralDetection_GrammarDriven(t *testing.T) {
 	t.Run("positive_cross_join_lateral_func_with_outer_correlation", func(t *testing.T) {
 		// CROSS JOIN LATERAL <func>(c.alias_ref) — outer alias `c` referenced.

--- a/select.go
+++ b/select.go
@@ -347,10 +347,6 @@ func collectTableRefs(result *ParsedQuery, ref gen.ITable_refContext, tokens ant
 			Type:  TableTypeFunction,
 			Raw:   tableName,
 		})
-		// Check for LATERAL correlation via the grammar's LATERAL_P terminal,
-		// not a substring scan of the rendered text. Identifiers whose names
-		// contain the literal "lateral" (e.g. bilateral_offsets) must not
-		// trigger detection.
 		if ref.LATERAL_P() != nil {
 			detectLateralCorrelation(result, fn, tokens)
 		}

--- a/select.go
+++ b/select.go
@@ -347,11 +347,12 @@ func collectTableRefs(result *ParsedQuery, ref gen.ITable_refContext, tokens ant
 			Type:  TableTypeFunction,
 			Raw:   tableName,
 		})
-		// Check for LATERAL correlation
-		if prc, ok := ref.(antlr.ParserRuleContext); ok {
-			if strings.Contains(strings.ToUpper(ctxText(tokens, prc)), "LATERAL") {
-				detectLateralCorrelation(result, fn, tokens)
-			}
+		// Check for LATERAL correlation via the grammar's LATERAL_P terminal,
+		// not a substring scan of the rendered text. Identifiers whose names
+		// contain the literal "lateral" (e.g. bilateral_offsets) must not
+		// trigger detection.
+		if ref.LATERAL_P() != nil {
+			detectLateralCorrelation(result, fn, tokens)
 		}
 	} else if sub := ref.Select_with_parens(); sub != nil {
 		alias := aliasFromAliasClause(ref.Alias_clause(), tokens)


### PR DESCRIPTION
## Summary

- Replace the `strings.Contains(...,"LATERAL")` scan in `collectTableRefs` with the grammar's `LATERAL_P()` terminal accessor on `ITable_refContext`. The terminal is non-nil only when the LATERAL keyword actually appears at that grammar position.
- Identifiers whose names contain the substring `lateral` (e.g. `bilateral_offsets`, `lateral_metrics`, alias `lateral_alias`) no longer false-trigger `detectLateralCorrelation`.
- `detectLateralCorrelation`'s per-alias word-boundary matching (`containsWordDot`) is unchanged.

## Layer

- [x] Core parser (`select.go`)

## SQL examples

```sql
-- Before: false-positive — substring "lateral" in table name triggers detection.
SELECT * FROM bilateral_offsets bo
  CROSS JOIN generate_series(1, 10) AS gs;

-- After: no LATERAL keyword present, no detection. Correlations stays empty.

-- Genuine LATERAL still detected:
SELECT * FROM customers c
  CROSS JOIN LATERAL generate_series(1, c.id) AS gs;
-- → Correlations contains {OuterAlias: "c", Type: "LATERAL", ...}
```

## Test plan

- [x] New table-driven test `TestIR_LateralDetection_GrammarDriven` with 5 subtests:
  - **Positive**: `CROSS JOIN LATERAL generate_series(1, c.id)` → correlation on `c` populated.
  - **Negative**: substring `lateral` in table name (`bilateral_offsets`), column name (`lateral_value`), string literal (`'lateral metric notes'`), and alias (`lateral_alias`) — `Correlations` empty in all four.
- [x] `go test -race ./...` passes (all packages)
- [x] `golangci-lint run ./...` — 0 issues
- [x] Existing LATERAL tests untouched and passing: `TestIR_LateralCorrelationNoFalseMatch`, `TestIR_LateralJoinWithSubquery`, `TestIR_LateralJoinWithFunction`, `TestIR_ComplexMonsterQuery`.

## Behavioral impact

More correct. Genuine LATERAL queries behave exactly as before. Only false-positive detection is removed.

## Out of scope (per the issue)

- Shape of `Correlation` results — unchanged.
- LATERAL improvements unrelated to detection accuracy (e.g. inferring correlated columns more precisely on LATERAL `(SELECT ...)` and other table_ref alternatives that the existing code never handled — separate concern).

## Related issues

Closes #58

## Checklist

- [x] No changes to `gen/` (auto-generated ANTLR code)
- [x] N/A (no new IR fields)
- [x] N/A (no public API changes — internal detection mechanism only)