### PR TITLE
feat(errors): show source line with caret in parse diagnostics

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -44,9 +44,6 @@ type SyntaxError struct {
 	Message string
 	// TokenIndex is the offending token index when available; -1 when unknown.
 	TokenIndex int
-	// TokenLength is the rune length of the offending token, used for caret
-	// width. Zero when unknown, in which case a single caret is rendered.
-	TokenLength int
 }
 
 // ParseErrors aggregates syntax errors encountered while parsing a SQL string.
@@ -85,14 +82,8 @@ func formatSyntaxError(err SyntaxError, lines []string) string {
 	gutter := fmt.Sprintf("  %d | ", err.Line)
 	caretPad := strings.Repeat(" ", len(gutter)) + caretIndent(src, err.Column)
 
-	width := err.TokenLength
-	if width < 1 {
-		width = 1
-	}
-	caret := strings.Repeat("^", width)
-
-	return fmt.Sprintf("%s\n%s%s\n%s%s\n%s%s",
-		header, gutter, src, caretPad, caret, strings.Repeat(" ", len(gutter)), err.Message)
+	return fmt.Sprintf("%s\n%s%s\n%s^\n%s%s",
+		header, gutter, src, caretPad, strings.Repeat(" ", len(gutter)), err.Message)
 }
 
 // caretIndent builds the whitespace that positions a caret under column col of
@@ -138,16 +129,13 @@ type parseErrorListener struct {
 func (l *parseErrorListener) SyntaxError(recognizer antlr.Recognizer, offendingSymbol interface{},
 	line, column int, msg string, e antlr.RecognitionException) {
 	tokenIndex := -1
-	tokenLength := 0
 	if tok, ok := offendingSymbol.(antlr.Token); ok && tok != nil {
 		tokenIndex = tok.GetTokenIndex()
-		tokenLength = len([]rune(tok.GetText()))
 	}
 	l.errs = append(l.errs, SyntaxError{
-		Line:        line,
-		Column:      column,
-		Message:     msg,
-		TokenIndex:  tokenIndex,
-		TokenLength: tokenLength,
+		Line:       line,
+		Column:     column,
+		Message:    msg,
+		TokenIndex: tokenIndex,
 	})
 }

--- a/errors.go
+++ b/errors.go
@@ -44,6 +44,9 @@ type SyntaxError struct {
 	Message string
 	// TokenIndex is the offending token index when available; -1 when unknown.
 	TokenIndex int
+	// TokenLength is the rune length of the offending token, used for caret
+	// width. Zero when unknown, in which case a single caret is rendered.
+	TokenLength int
 }
 
 // ParseErrors aggregates syntax errors encountered while parsing a SQL string.
@@ -52,20 +55,62 @@ type ParseErrors struct {
 	Errors []SyntaxError
 }
 
-// Error formats the aggregated syntax errors into a single string.
+// Error formats the aggregated syntax errors, rendering each as a source line
+// with a caret pointing at the offending token. Multiple errors are separated
+// by a blank line.
 func (p *ParseErrors) Error() string {
 	if p == nil || len(p.Errors) == 0 {
 		return "parse error"
 	}
-	if len(p.Errors) == 1 {
-		err := p.Errors[0]
-		return fmt.Sprintf("parse error: line %d:%d %s", err.Line, err.Column, err.Message)
-	}
-	parts := make([]string, len(p.Errors))
+	lines := strings.Split(p.SQL, "\n")
+	blocks := make([]string, len(p.Errors))
 	for i, err := range p.Errors {
-		parts[i] = fmt.Sprintf("line %d:%d %s", err.Line, err.Column, err.Message)
+		blocks[i] = formatSyntaxError(err, lines)
 	}
-	return fmt.Sprintf("parse error(s): %s", strings.Join(parts, "; "))
+	return strings.Join(blocks, "\n\n")
+}
+
+// formatSyntaxError renders one syntax error. When the source line is
+// available it shows that line with a caret underneath; otherwise it falls
+// back to the header plus message only.
+func formatSyntaxError(err SyntaxError, lines []string) string {
+	header := fmt.Sprintf("parse error at line %d:%d", err.Line, err.Column)
+
+	idx := err.Line - 1
+	if idx < 0 || idx >= len(lines) {
+		return fmt.Sprintf("%s\n  %s", header, err.Message)
+	}
+
+	src := lines[idx]
+	gutter := fmt.Sprintf("  %d | ", err.Line)
+	caretPad := strings.Repeat(" ", len(gutter)) + caretIndent(src, err.Column)
+
+	width := err.TokenLength
+	if width < 1 {
+		width = 1
+	}
+	caret := strings.Repeat("^", width)
+
+	return fmt.Sprintf("%s\n%s%s\n%s%s\n%s%s",
+		header, gutter, src, caretPad, caret, strings.Repeat(" ", len(gutter)), err.Message)
+}
+
+// caretIndent builds the whitespace that positions a caret under column col of
+// src, preserving tabs so alignment holds in tab-indented input.
+func caretIndent(src string, col int) string {
+	if col < 0 {
+		col = 0
+	}
+	runes := []rune(src)
+	var b strings.Builder
+	for i := 0; i < col; i++ {
+		if i < len(runes) && runes[i] == '\t' {
+			b.WriteByte('\t')
+		} else {
+			b.WriteByte(' ')
+		}
+	}
+	return b.String()
 }
 
 // replaceErrorListeners removes ANTLR's default console listener so parse
@@ -93,13 +138,16 @@ type parseErrorListener struct {
 func (l *parseErrorListener) SyntaxError(recognizer antlr.Recognizer, offendingSymbol interface{},
 	line, column int, msg string, e antlr.RecognitionException) {
 	tokenIndex := -1
+	tokenLength := 0
 	if tok, ok := offendingSymbol.(antlr.Token); ok && tok != nil {
 		tokenIndex = tok.GetTokenIndex()
+		tokenLength = len([]rune(tok.GetText()))
 	}
 	l.errs = append(l.errs, SyntaxError{
-		Line:       line,
-		Column:     column,
-		Message:    msg,
-		TokenIndex: tokenIndex,
+		Line:        line,
+		Column:      column,
+		Message:     msg,
+		TokenIndex:  tokenIndex,
+		TokenLength: tokenLength,
 	})
 }

--- a/parser_ir_edge_cases_test.go
+++ b/parser_ir_edge_cases_test.go
@@ -1237,48 +1237,6 @@ func TestIR_SemicolonOnly(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// ParseErrors formatting
-// ---------------------------------------------------------------------------
-
-// TestParseErrors_Error_NilReceiver validates Error() on a nil ParseErrors receiver.
-func TestParseErrors_Error_NilReceiver(t *testing.T) {
-	var pe *ParseErrors
-	assert.Equal(t, "parse error", pe.Error(), "expected 'parse error'")
-}
-
-// TestParseErrors_Error_Empty checks Error() with an empty error list.
-func TestParseErrors_Error_Empty(t *testing.T) {
-	pe := &ParseErrors{SQL: "test", Errors: nil}
-	assert.Equal(t, "parse error", pe.Error(), "expected 'parse error'")
-}
-
-// TestParseErrors_Error_Single verifies Error() formatting with one syntax error.
-func TestParseErrors_Error_Single(t *testing.T) {
-	pe := &ParseErrors{
-		SQL:    "test",
-		Errors: []SyntaxError{{Line: 1, Column: 5, Message: "bad token"}},
-	}
-	s := pe.Error()
-	assert.Contains(t, s, "line 1:5", "unexpected error string")
-	assert.Contains(t, s, "bad token", "unexpected error string")
-}
-
-// TestParseErrors_Error_Multiple confirms Error() formatting with multiple syntax errors.
-func TestParseErrors_Error_Multiple(t *testing.T) {
-	pe := &ParseErrors{
-		SQL: "test",
-		Errors: []SyntaxError{
-			{Line: 1, Column: 5, Message: "bad token"},
-			{Line: 2, Column: 3, Message: "unexpected EOF"},
-		},
-	}
-	s := pe.Error()
-	assert.Contains(t, s, "parse error(s)", "expected 'parse error(s)'")
-	assert.Contains(t, s, "line 1:5", "expected error location 1")
-	assert.Contains(t, s, "line 2:3", "expected error location 2")
-}
-
-// ---------------------------------------------------------------------------
 // Subquery with LIMIT (IsNested flag)
 // ---------------------------------------------------------------------------
 

--- a/parser_ir_error_test.go
+++ b/parser_ir_error_test.go
@@ -40,3 +40,41 @@ SELECT`
 
 	assert.Contains(t, perr.Error(), "line", "expected error message to include line information")
 }
+
+// TestParseErrors_Error_NilReceiver validates Error() on a nil ParseErrors receiver.
+func TestParseErrors_Error_NilReceiver(t *testing.T) {
+	var pe *ParseErrors
+	assert.Equal(t, "parse error", pe.Error(), "expected 'parse error'")
+}
+
+// TestParseErrors_Error_Empty checks Error() with an empty error list.
+func TestParseErrors_Error_Empty(t *testing.T) {
+	pe := &ParseErrors{SQL: "test", Errors: nil}
+	assert.Equal(t, "parse error", pe.Error(), "expected 'parse error'")
+}
+
+// TestParseErrors_Error_Single verifies Error() formatting with one syntax error.
+func TestParseErrors_Error_Single(t *testing.T) {
+	pe := &ParseErrors{
+		SQL:    "test",
+		Errors: []SyntaxError{{Line: 1, Column: 5, Message: "bad token"}},
+	}
+	s := pe.Error()
+	assert.Contains(t, s, "line 1:5", "unexpected error string")
+	assert.Contains(t, s, "bad token", "unexpected error string")
+}
+
+// TestParseErrors_Error_Multiple confirms Error() formatting with multiple syntax errors.
+func TestParseErrors_Error_Multiple(t *testing.T) {
+	pe := &ParseErrors{
+		SQL: "test",
+		Errors: []SyntaxError{
+			{Line: 1, Column: 5, Message: "bad token"},
+			{Line: 2, Column: 3, Message: "unexpected EOF"},
+		},
+	}
+	s := pe.Error()
+	assert.Contains(t, s, "line 1:5", "expected error location 1")
+	assert.Contains(t, s, "line 2:3", "expected error location 2")
+	assert.Contains(t, s, "\n\n", "expected blank line separating error blocks")
+}

--- a/parser_ir_error_test.go
+++ b/parser_ir_error_test.go
@@ -2,6 +2,7 @@
 package postgresparser
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -77,4 +78,73 @@ func TestParseErrors_Error_Multiple(t *testing.T) {
 	assert.Contains(t, s, "line 1:5", "expected error location 1")
 	assert.Contains(t, s, "line 2:3", "expected error location 2")
 	assert.Contains(t, s, "\n\n", "expected blank line separating error blocks")
+}
+
+// TestParseErrors_Error_CaretWidthMatchesTokenLength checks the caret spans the
+// whole offending token when its length is known.
+func TestParseErrors_Error_CaretWidthMatchesTokenLength(t *testing.T) {
+	pe := &ParseErrors{
+		SQL:    "SELECT FROM",
+		Errors: []SyntaxError{{Line: 1, Column: 7, Message: "bad", TokenLength: 4}},
+	}
+	caret := caretLineOf(t, pe.Error())
+	assert.Equal(t, "^^^^", strings.TrimLeft(caret, " "), "caret width should equal token length")
+}
+
+// TestParseErrors_Error_SingleCaretWhenTokenLengthUnknown checks a zero token
+// length degrades to a single caret rather than an empty one.
+func TestParseErrors_Error_SingleCaretWhenTokenLengthUnknown(t *testing.T) {
+	pe := &ParseErrors{
+		SQL:    "SELECT FROM",
+		Errors: []SyntaxError{{Line: 1, Column: 7, Message: "bad"}},
+	}
+	caret := caretLineOf(t, pe.Error())
+	assert.Equal(t, "^", strings.TrimLeft(caret, " "), "expected a single caret when token length is unknown")
+}
+
+// TestParseErrors_Error_LineOutOfRange checks errors pointing past the last
+// source line fall back to header + message with no caret.
+func TestParseErrors_Error_LineOutOfRange(t *testing.T) {
+	pe := &ParseErrors{
+		SQL:    "SELECT 1",
+		Errors: []SyntaxError{{Line: 5, Column: 0, Message: "unexpected EOF"}},
+	}
+	s := pe.Error()
+	assert.Contains(t, s, "parse error at line 5:0", "expected the header for the reported position")
+	assert.Contains(t, s, "unexpected EOF", "expected the underlying message")
+	assert.NotContains(t, s, "^", "expected no caret when the source line is unavailable")
+}
+
+// TestParseErrors_Error_SelectsReportedSourceLine checks the rendered block
+// quotes the line named by the error, not earlier lines.
+func TestParseErrors_Error_SelectsReportedSourceLine(t *testing.T) {
+	pe := &ParseErrors{
+		SQL:    "SELECT a\nFROM t\nWHERE",
+		Errors: []SyntaxError{{Line: 3, Column: 0, Message: "incomplete", TokenLength: 5}},
+	}
+	s := pe.Error()
+	assert.Contains(t, s, "3 | WHERE", "expected the line-3 source in the gutter")
+	assert.NotContains(t, s, "SELECT a", "expected unrelated source lines to be omitted")
+}
+
+// TestParseErrors_Error_PreservesTabIndent checks the caret indent keeps tabs so
+// alignment holds under tab-indented input.
+func TestParseErrors_Error_PreservesTabIndent(t *testing.T) {
+	pe := &ParseErrors{
+		SQL:    "SELECT\n\tFROM x",
+		Errors: []SyntaxError{{Line: 2, Column: 1, Message: "bad", TokenLength: 4}},
+	}
+	caret := caretLineOf(t, pe.Error())
+	assert.Contains(t, caret, "\t", "caret indent should preserve the source tab")
+}
+
+func caretLineOf(t *testing.T, rendered string) string {
+	t.Helper()
+	for _, line := range strings.Split(rendered, "\n") {
+		if strings.Contains(line, "^") {
+			return line
+		}
+	}
+	t.Fatalf("no caret line in rendered error:\n%s", rendered)
+	return ""
 }

--- a/parser_ir_error_test.go
+++ b/parser_ir_error_test.go
@@ -80,26 +80,16 @@ func TestParseErrors_Error_Multiple(t *testing.T) {
 	assert.Contains(t, s, "\n\n", "expected blank line separating error blocks")
 }
 
-// TestParseErrors_Error_CaretWidthMatchesTokenLength checks the caret spans the
-// whole offending token when its length is known.
-func TestParseErrors_Error_CaretWidthMatchesTokenLength(t *testing.T) {
-	pe := &ParseErrors{
-		SQL:    "SELECT FROM",
-		Errors: []SyntaxError{{Line: 1, Column: 7, Message: "bad", TokenLength: 4}},
-	}
-	caret := caretLineOf(t, pe.Error())
-	assert.Equal(t, "^^^^", strings.TrimLeft(caret, " "), "caret width should equal token length")
-}
-
-// TestParseErrors_Error_SingleCaretWhenTokenLengthUnknown checks a zero token
-// length degrades to a single caret rather than an empty one.
-func TestParseErrors_Error_SingleCaretWhenTokenLengthUnknown(t *testing.T) {
+// TestParseErrors_Error_RendersSingleCaret checks the caret line carries exactly
+// one caret positioned at the reported column.
+func TestParseErrors_Error_RendersSingleCaret(t *testing.T) {
 	pe := &ParseErrors{
 		SQL:    "SELECT FROM",
 		Errors: []SyntaxError{{Line: 1, Column: 7, Message: "bad"}},
 	}
 	caret := caretLineOf(t, pe.Error())
-	assert.Equal(t, "^", strings.TrimLeft(caret, " "), "expected a single caret when token length is unknown")
+	assert.Equal(t, "^", strings.TrimLeft(caret, " "), "expected a single caret")
+	assert.Equal(t, len("  1 | ")+7, strings.IndexByte(caret, '^'), "caret should sit at the reported column")
 }
 
 // TestParseErrors_Error_LineOutOfRange checks errors pointing past the last
@@ -120,7 +110,7 @@ func TestParseErrors_Error_LineOutOfRange(t *testing.T) {
 func TestParseErrors_Error_SelectsReportedSourceLine(t *testing.T) {
 	pe := &ParseErrors{
 		SQL:    "SELECT a\nFROM t\nWHERE",
-		Errors: []SyntaxError{{Line: 3, Column: 0, Message: "incomplete", TokenLength: 5}},
+		Errors: []SyntaxError{{Line: 3, Column: 0, Message: "incomplete"}},
 	}
 	s := pe.Error()
 	assert.Contains(t, s, "3 | WHERE", "expected the line-3 source in the gutter")
@@ -132,7 +122,7 @@ func TestParseErrors_Error_SelectsReportedSourceLine(t *testing.T) {
 func TestParseErrors_Error_PreservesTabIndent(t *testing.T) {
 	pe := &ParseErrors{
 		SQL:    "SELECT\n\tFROM x",
-		Errors: []SyntaxError{{Line: 2, Column: 1, Message: "bad", TokenLength: 4}},
+		Errors: []SyntaxError{{Line: 2, Column: 1, Message: "bad"}},
 	}
 	caret := caretLineOf(t, pe.Error())
 	assert.Contains(t, caret, "\t", "caret indent should preserve the source tab")

--- a/parser_test.go
+++ b/parser_test.go
@@ -727,3 +727,34 @@ func TestParseSQLStrictWithOptions_Table(t *testing.T) {
 		})
 	}
 }
+
+func TestParseErrorRendersSourceLineWithCaret(t *testing.T) {
+	_, err := ParseSQL("SELECT FROM")
+
+	var perr *ParseErrors
+	require.ErrorAs(t, err, &perr)
+	require.Len(t, perr.Errors, 1)
+
+	got := perr.Error()
+	first := perr.Errors[0]
+
+	assert.Contains(t, got, "SELECT FROM", "expected the offending source line")
+	assert.Contains(t, got, "1 | SELECT FROM", "expected a numbered source gutter")
+	assert.Contains(t, got, "^", "expected a caret pointing at the offending token")
+	assert.Contains(t, got, first.Message, "expected the underlying parser message")
+
+	caretLine := caretLineFor(t, got)
+	assert.Equal(t, first.Column, strings.IndexByte(caretLine, '^')-len("  1 | "),
+		"caret column should align with the reported error column")
+}
+
+func caretLineFor(t *testing.T, rendered string) string {
+	t.Helper()
+	for _, line := range strings.Split(rendered, "\n") {
+		if strings.Contains(line, "^") {
+			return line
+		}
+	}
+	t.Fatalf("no caret line in rendered error:\n%s", rendered)
+	return ""
+}


### PR DESCRIPTION
## Summary

- `ParseErrors.Error()` now renders each syntax error as the offending source line plus a caret pointing at the failing token, instead of a bare `line:column` reference. Multiple errors print as blocks separated by a blank line.
- A single `^` is rendered at the reported column (per the issue). Tabs in the source line are preserved so the caret stays aligned in tab-indented input.
- Out-of-range lines (e.g. an `<EOF>` error past the last line) fall back to the header + message only. No API changes.
- Consolidate the `ParseErrors` formatting tests into `parser_ir_error_test.go` (out of the catch-all `parser_ir_edge_cases_test.go`), continuing the effort to unflatten the test layout.

## Layer

- [x] Core error formatting (`errors.go`)
- [x] Tests

## SQL examples

```sql
SELECT FROM
```

renders:

```
parse error at line 1:11
  1 | SELECT FROM
                 ^
      mismatched input '<EOF>' expecting { ... }
```

## Test plan

- [x] New `TestParseErrorRendersSourceLineWithCaret` in `parser_test.go` (per the issue): asserts the numbered source gutter, caret presence, underlying parser message, and that the caret column aligns with the reported error column.
- [x] `parser_ir_error_test.go` unit-covers the formatting branches: single caret at the reported column, multi-error blank-line separation, header-only fallback when the line is past the source, source-line selection in multi-line input, and tab-preserving caret alignment.
- [x] Existing `parser_test.go` and `antlr_stderr_test.go` error assertions still pass (they check error types and `.Message`, not the formatted string).
- [x] `go test -race -count=1 ./...` passes (all packages)
- [x] `go vet . ./analysis/...` clean
- [x] `golangci-lint run ./...` — 0 issues

## Behavioral impact

The `Error()` string format changes (this is the point of the issue). No exported types or signatures change: `ParseErrors` and `SyntaxError` keep their existing shape, so callers matching on `SyntaxError.Line/Column/Message` are unaffected.

## Out of scope (per the issue)

- Color output — kept plain text.
- Multi-line spans.
- Token-width carets — a single caret is rendered to avoid any public struct-layout change to `SyntaxError`.
- Trimming ANTLR's long `expecting { ... }` token list — left verbatim.

## Related issues

Closes #65

## Checklist

- [x] No changes to `gen/` (auto-generated ANTLR code)
- [x] No new IR fields
- [x] No public API changes
