### PR TITLE
feat(ddl): capture CREATE INDEX INCLUDE columns and partial WHERE predicate

### DIFF
--- a/analysis/analysis.go
+++ b/analysis/analysis.go
@@ -463,17 +463,19 @@ func convertDDLActions(actions []postgresparser.DDLAction) []SQLDDLAction {
 	out := make([]SQLDDLAction, 0, len(actions))
 	for _, a := range actions {
 		out = append(out, SQLDDLAction{
-			Type:          string(a.Type),
-			ObjectName:    a.ObjectName,
-			ObjectType:    a.ObjectType,
-			Schema:        a.Schema,
-			Columns:       append([]string(nil), a.Columns...),
-			ColumnDetails: convertDDLColumns(a.ColumnDetails),
-			Constraints:   convertDDLConstraints(a.Constraints),
-			Flags:         append([]string(nil), a.Flags...),
-			IndexType:     a.IndexType,
-			Target:        a.Target,
-			Comment:       a.Comment,
+			Type:           string(a.Type),
+			ObjectName:     a.ObjectName,
+			ObjectType:     a.ObjectType,
+			Schema:         a.Schema,
+			Columns:        append([]string(nil), a.Columns...),
+			ColumnDetails:  convertDDLColumns(a.ColumnDetails),
+			Constraints:    convertDDLConstraints(a.Constraints),
+			Flags:          append([]string(nil), a.Flags...),
+			IndexType:      a.IndexType,
+			IncludeColumns: append([]string(nil), a.IncludeColumns...),
+			Predicate:      a.Predicate,
+			Target:         a.Target,
+			Comment:        a.Comment,
 		})
 	}
 	return out

--- a/analysis/analysis_ddl_test.go
+++ b/analysis/analysis_ddl_test.go
@@ -343,6 +343,30 @@ func TestAnalyzeSQL_DDL_CreateIndex(t *testing.T) {
 	}
 }
 
+// TestAnalyzeSQL_DDL_CreateIndex_IncludeAndPredicate checks the analysis DTO
+// mirrors INCLUDE columns and the partial-index WHERE predicate.
+func TestAnalyzeSQL_DDL_CreateIndex_IncludeAndPredicate(t *testing.T) {
+	sql := `CREATE INDEX idx_users_active_email
+ON users (email)
+INCLUDE (last_login_at)
+WHERE active = true`
+
+	res, err := AnalyzeSQL(sql)
+	if err != nil {
+		t.Fatalf("AnalyzeSQL failed: %v", err)
+	}
+	if len(res.DDLActions) != 1 {
+		t.Fatalf("expected 1 DDL action, got %d", len(res.DDLActions))
+	}
+
+	act := res.DDLActions[0]
+	if act.Type != "CREATE_INDEX" {
+		t.Fatalf("expected CREATE_INDEX, got %s", act.Type)
+	}
+	require.Equal(t, []string{"last_login_at"}, act.IncludeColumns, "IncludeColumns mismatch")
+	require.Equal(t, "active = true", act.Predicate, "Predicate mismatch")
+}
+
 func TestAnalyzeSQL_DDL_CreateIndex_QualifiedIndexNameNormalization(t *testing.T) {
 	res, err := AnalyzeSQL("CREATE INDEX analytics.idx_users_email ON public.users (email)")
 	if err != nil {

--- a/analysis/types.go
+++ b/analysis/types.go
@@ -285,8 +285,14 @@ type SQLDDLAction struct {
 	Constraints   *SQLDDLConstraints
 	Flags         []string
 	IndexType     string
-	Target        string
-	Comment       string
+	// IncludeColumns lists non-key columns from CREATE INDEX ... INCLUDE (...).
+	IncludeColumns []string
+	// Predicate is the partial-index expression from CREATE INDEX ... WHERE ...
+	// (the bare expression, without the leading WHERE keyword). Empty when the
+	// index is not partial.
+	Predicate string
+	Target    string
+	Comment   string
 }
 
 // SQLParseWarningCode identifies non-fatal parser notices in analysis batch results.

--- a/ddl.go
+++ b/ddl.go
@@ -801,18 +801,43 @@ func populateCreateIndex(result *ParsedQuery, ctx gen.IIndexstmtContext, tokens 
 		}
 	}
 
+	var includeColumns []string
+	if inc := ctx.Include_(); inc != nil {
+		if params := inc.Index_including_params(); params != nil {
+			for _, elem := range params.AllIndex_elem() {
+				prc, ok := elem.(antlr.ParserRuleContext)
+				if !ok {
+					continue
+				}
+				name := strings.TrimSpace(ctxText(tokens, prc))
+				if name != "" {
+					includeColumns = append(includeColumns, name)
+				}
+			}
+		}
+	}
+
+	predicate := ""
+	if wc := ctx.Where_clause(); wc != nil {
+		if expr := wc.A_expr(); expr != nil {
+			predicate = strings.TrimSpace(ctxText(tokens, expr))
+		}
+	}
+
 	indexSchema, indexName := splitQualifiedName(indexRaw)
 	if indexSchema == "" {
 		indexSchema = tableSchema
 	}
 
 	action := DDLAction{
-		Type:       DDLCreateIndex,
-		ObjectName: indexName,
-		Schema:     indexSchema,
-		Columns:    columns,
-		Flags:      flags,
-		IndexType:  indexType,
+		Type:           DDLCreateIndex,
+		ObjectName:     indexName,
+		Schema:         indexSchema,
+		Columns:        columns,
+		Flags:          flags,
+		IndexType:      indexType,
+		IncludeColumns: includeColumns,
+		Predicate:      predicate,
 	}
 	result.DDLActions = append(result.DDLActions, action)
 	return nil

--- a/docs/parsed-query.md
+++ b/docs/parsed-query.md
@@ -140,6 +140,8 @@ Common DDL action fields:
 - `Columns`: Column names or indexed expressions relevant to the action.
 - `Flags`: Modifiers like `IF_EXISTS`, `IF_NOT_EXISTS`, `CASCADE`, `CONCURRENTLY`, etc.
 - `IndexType`: Index method for `CREATE_INDEX` (for example `btree`, `gin`).
+- `IncludeColumns`: Non-key columns from `CREATE INDEX ... INCLUDE (...)`. Empty for indexes without an `INCLUDE` clause.
+- `Predicate`: Partial-index expression from `CREATE INDEX ... WHERE ...`, captured as text without the leading `WHERE` keyword. Empty for non-partial indexes.
 - `ColumnDetails`: Column metadata for `CREATE_TABLE` actions.
 - `Constraints`: Optional `*DDLConstraints` grouping PK/FK/UNIQUE/CHECK metadata (`CREATE_TABLE`, `ALTER_TABLE ADD CONSTRAINT`).
 - `Target`: Generic fully-qualified target path for comment-like actions (for example `public.users.email`).

--- a/docs/supported-statements.md
+++ b/docs/supported-statements.md
@@ -23,7 +23,7 @@ These statements are walked via ANTLR visitors and produce rich IR metadata in `
 | `CREATE TABLE` | `DDL` | `Tables`, `DDLActions` (with `ColumnDetails`, `Constraints`: PK/FK/UNIQUE/CHECK) |
 | `ALTER TABLE` | `DDL` | `Tables`, `DDLActions` (including `Constraints` on `ADD CONSTRAINT`: PK/FK/UNIQUE/CHECK) |
 | `DROP TABLE` / `DROP INDEX` | `DDL` | `DDLActions` (with `Flags`) |
-| `CREATE INDEX` | `DDL` | `DDLActions` (with `IndexType`) |
+| `CREATE INDEX` | `DDL` | `DDLActions` (with `IndexType`, `IncludeColumns`, `Predicate` for partial-index `WHERE`) |
 | `TRUNCATE` | `DDL` | `Tables`, `DDLActions` |
 | `COMMENT ON` | `DDL` | `DDLActions` (with `Type=COMMENT`, `ObjectType`, `ObjectName`, `Schema`, `Target`, `Comment`) |
 

--- a/ir.go
+++ b/ir.go
@@ -198,8 +198,14 @@ type DDLAction struct {
 	Constraints   *DDLConstraints // PK/FK/UNIQUE constraint metadata (CREATE TABLE, ALTER TABLE ADD CONSTRAINT)
 	Flags         []string        // IF_EXISTS, CONCURRENTLY, CASCADE, etc.
 	IndexType     string          // btree, gin, gist, hash (CREATE INDEX only)
-	Target        string          // Generic fully-qualified target path for comment-like actions.
-	Comment       string          // Comment text for COMMENT ON statements.
+	// IncludeColumns lists non-key columns from CREATE INDEX ... INCLUDE (...).
+	IncludeColumns []string
+	// Predicate is the partial-index expression from CREATE INDEX ... WHERE ...
+	// (the bare expression, without the leading WHERE keyword). Empty when the
+	// index is not partial.
+	Predicate string
+	Target    string // Generic fully-qualified target path for comment-like actions.
+	Comment   string // Comment text for COMMENT ON statements.
 }
 
 // SubqueryRef records metadata for subqueries discovered in FROM or set operations.

--- a/parser_ir_ddl_test.go
+++ b/parser_ir_ddl_test.go
@@ -302,6 +302,56 @@ func TestIR_DDL_CreateIndex_OnlyRelationRawPreserved(t *testing.T) {
 	assert.Equal(t, "ONLY public.users", ir.Tables[0].Raw, "table raw mismatch")
 }
 
+// TestIR_DDL_CreateIndex_IncludeAndPredicate verifies that INCLUDE columns and
+// the partial-index WHERE predicate are captured on the CREATE_INDEX action.
+func TestIR_DDL_CreateIndex_IncludeAndPredicate(t *testing.T) {
+	tests := []struct {
+		name          string
+		sql           string
+		wantInclude   []string
+		wantPredicate string
+	}{
+		{
+			name: "include columns and partial predicate",
+			sql: `CREATE INDEX idx_users_active_email
+ON users (email)
+INCLUDE (last_login_at)
+WHERE active = true`,
+			wantInclude:   []string{"last_login_at"},
+			wantPredicate: "active = true",
+		},
+		{
+			name:          "multiple include columns, no predicate",
+			sql:           `CREATE INDEX idx_users_email ON users (email) INCLUDE (name, last_login_at)`,
+			wantInclude:   []string{"name", "last_login_at"},
+			wantPredicate: "",
+		},
+		{
+			name:          "partial predicate only",
+			sql:           `CREATE INDEX idx_users_partial ON users (email) WHERE created_at > '2024-01-01'`,
+			wantInclude:   nil,
+			wantPredicate: "created_at > '2024-01-01'",
+		},
+		{
+			name:          "plain index leaves both fields empty",
+			sql:           `CREATE INDEX idx_users_email ON users (email)`,
+			wantInclude:   nil,
+			wantPredicate: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ir := parseAssertNoError(t, tc.sql)
+			require.Len(t, ir.DDLActions, 1, "action count mismatch")
+			act := ir.DDLActions[0]
+			assert.Equal(t, DDLCreateIndex, act.Type, "expected CREATE_INDEX")
+			assert.Equal(t, tc.wantInclude, act.IncludeColumns, "IncludeColumns mismatch")
+			assert.Equal(t, tc.wantPredicate, act.Predicate, "Predicate mismatch")
+		})
+	}
+}
+
 func TestIR_DDL_CreateTable(t *testing.T) {
 	sql := `CREATE TABLE public.users (
     id integer NOT NULL,


### PR DESCRIPTION
## Summary

- `populateCreateIndex` now reads `ctx.Include_()` and `ctx.Where_clause()` from the generated parser and surfaces them on `DDLAction` as two new fields:
  - `IncludeColumns []string` — non-key columns from `INCLUDE (...)`.
  - `Predicate string` — the partial-index expression from `WHERE ...`, captured as plain text without the leading `WHERE` keyword.
- The analysis-layer DTO `SQLDDLAction` mirrors both fields and `convertDDLActions` copies them across, so analysis callers see the same data.
- Documentation under `docs/parsed-query.md` and `docs/supported-statements.md` describes the new fields on `CREATE_INDEX`.

## Layer

- [x] Parser IR (`ir.go`, `ddl.go`)
- [x] Analysis layer (`analysis/types.go`, `analysis/analysis.go`)
- [x] Tests
- [x] Documentation

## SQL examples

```sql
CREATE INDEX idx_users_active_email
ON users (email)
INCLUDE (last_login_at)
WHERE active = true;
```

extracts:

- `Columns:        ["email"]`
- `IncludeColumns: ["last_login_at"]`
- `Predicate:      "active = true"`

Other partials supported:

```sql
-- INCLUDE only
CREATE INDEX idx ON users (email) INCLUDE (name, last_login_at);

-- Partial only
CREATE INDEX idx ON users (email) WHERE created_at > '2024-01-01';
```

## Test plan

- [x] New IR test `TestIR_DDL_CreateIndex_IncludeAndPredicate` covering: both clauses, multi-column `INCLUDE`, partial-only, and the plain index case (asserts both fields stay zero).
- [x] New analysis test `TestAnalyzeSQL_DDL_CreateIndex_IncludeAndPredicate` checking the DTO mirrors the new fields.
- [x] Existing `TestIR_DDL_CreateIndex`, `TestIR_DDL_CreateIndex_QualifiedIndexNameNormalization`, `TestIR_DDL_CreateIndex_OnlyRelationRawPreserved`, `TestAnalyzeSQL_DDL_CreateIndex` and friends still pass without modification (plain indexes get `nil` `IncludeColumns` and `""` `Predicate`).
- [x] `go test -race -count=1 ./...` passes (all packages)
- [x] `go vet . ./analysis/...` clean
- [x] `golangci-lint run ./...` — 0 issues

## Behavioral impact

Additive only. The two new fields on `DDLAction` / `SQLDDLAction` are zero for any statement that doesn't supply them, so callers matching on existing fields are unaffected. Pre-existing assertions about `act.Columns`, `act.Flags`, `act.IndexType`, etc. continue to hold for plain `CREATE INDEX` statements.

## Out of scope (per the issue)

- Full expression parsing for index predicates — the predicate is preserved as normalized token text.
- Reconstructing a complete `CREATE INDEX` statement from the IR.
- Validating whether included columns are legal for a given access method.

## Related issues

Closes #68

## Checklist

- [x] No changes to `gen/` (auto-generated ANTLR code)
- [x] Additive IR fields only (zero values for prior cases)
- [x] No public API signature changes
- [x] Documentation updated