### PR TITLE
feat(analysis): add ExtractWhereConditionsWithSchema for unqualified column resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,22 @@ for _, c := range conditions {
 // total > 100
 ```
 
+In multi-table queries, unqualified columns have an empty `Table`. Pass schema
+metadata to resolve them:
+
+```go
+schema := map[string][]analysis.ColumnSchema{
+    "orders":    {{Name: "id", IsPrimaryKey: true}, {Name: "customer_id"}, {Name: "total"}},
+    "customers": {{Name: "id", IsPrimaryKey: true}, {Name: "country"}},
+}
+
+conditions, _ := analysis.ExtractWhereConditionsWithSchema(
+    "SELECT * FROM orders o JOIN customers c ON o.customer_id = c.id WHERE total > 100",
+    schema,
+)
+// conditions[0].Table == "orders" — only orders has a "total" column
+```
+
 ### Placeholder roles
 
 `AnalyzeSQL` exposes the syntactic role of each `?` or `$N` placeholder without

--- a/analysis/combined_extractor.go
+++ b/analysis/combined_extractor.go
@@ -5,8 +5,10 @@ package analysis
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/valkdb/postgresparser"
+	"github.com/valkdb/postgresparser/internal/ident"
 )
 
 // QueryAnalysisResult holds the combined results of query analysis.
@@ -47,7 +49,7 @@ func ExtractQueryAnalysis(query string) (*QueryAnalysisResult, error) {
 	}
 
 	// Extract WHERE conditions from the parsed query
-	result.WhereConditions = extractWhereConditionsFromParsed(pq)
+	result.WhereConditions = extractWhereConditionsFromParsed(pq, nil)
 
 	// JoinRelationships is nil: FK detection requires schema metadata.
 	// Use ExtractQueryAnalysisWithSchema for FK relationship extraction.
@@ -55,9 +57,46 @@ func ExtractQueryAnalysis(query string) (*QueryAnalysisResult, error) {
 	return result, nil
 }
 
+// resolveColumnTableFromSchema resolves an unqualified column to its owning table
+// by looking it up across the query's base tables in schemaMap. Returns the table
+// name when exactly one base table contains the column, "" otherwise.
+func resolveColumnTableFromSchema(column string, tables []postgresparser.TableRef, schemaMap map[string][]ColumnSchema) string {
+	if len(schemaMap) == 0 {
+		return ""
+	}
+	col := strings.ToLower(ident.TrimQuotes(strings.TrimSpace(column)))
+	if col == "" {
+		return ""
+	}
+
+	match := ""
+	for _, table := range tables {
+		if table.Type != postgresparser.TableTypeBase {
+			continue
+		}
+		tableName := strings.ToLower(ident.TrimQuotes(strings.TrimSpace(table.Name)))
+		if tableName == "" || tableName == match {
+			continue
+		}
+		for _, cs := range schemaMap[tableName] {
+			if strings.ToLower(cs.Name) != col {
+				continue
+			}
+			if match != "" {
+				// Ambiguous: the column exists in more than one of the query's tables.
+				return ""
+			}
+			match = tableName
+			break
+		}
+	}
+	return match
+}
+
 // extractWhereConditionsFromParsed extracts WHERE conditions from an already-parsed query.
 // This is the internal implementation shared by both ExtractWhereConditions and ExtractQueryAnalysis.
-func extractWhereConditionsFromParsed(pq *postgresparser.ParsedQuery) []WhereCondition {
+// A non-nil schemaMap resolves unqualified columns in multi-table queries to their owning table.
+func extractWhereConditionsFromParsed(pq *postgresparser.ParsedQuery, schemaMap map[string][]ColumnSchema) []WhereCondition {
 	var conditions []WhereCondition
 	// WHERE extraction uses its own alias map that includes base tables, CTEs,
 	// and subqueries so Table resolution stays consistent across relation types.
@@ -82,9 +121,13 @@ func extractWhereConditionsFromParsed(pq *postgresparser.ParsedQuery) []WhereCon
 
 		// Resolve table name from alias, or use first table only for single-table queries.
 		tableName := resolveAlias(usage.TableAlias, aliasMap)
-		if tableName == "" && len(pq.Tables) == 1 {
-			// No alias and no resolution - default to first table only for single-table queries
-			tableName = pq.Tables[0].Name
+		if tableName == "" {
+			if len(pq.Tables) == 1 {
+				// No alias and no resolution - default to first table only for single-table queries
+				tableName = pq.Tables[0].Name
+			} else {
+				tableName = resolveColumnTableFromSchema(usage.Column, pq.Tables, schemaMap)
+			}
 		}
 
 		condition := WhereCondition{
@@ -123,7 +166,8 @@ func extractWhereConditionsFromParsed(pq *postgresparser.ParsedQuery) []WhereCon
 }
 
 // ExtractQueryAnalysisWithSchema parses a query and extracts analysis results,
-// using schema metadata to improve FK relationship inference accuracy.
+// using schema metadata for FK relationship inference and for resolving
+// unqualified WHERE columns to their owning table.
 //
 // Schema-aware extraction uses the IsPrimaryKey field from
 // schema metadata instead of heuristic name-based detection.
@@ -141,8 +185,8 @@ func ExtractQueryAnalysisWithSchema(query string, schemaMap map[string][]ColumnS
 		ParsedQuery: pq,
 	}
 
-	// Extract WHERE conditions (schema-independent)
-	result.WhereConditions = extractWhereConditionsFromParsed(pq)
+	// Extract WHERE conditions, resolving unqualified columns via schema metadata
+	result.WhereConditions = extractWhereConditionsFromParsed(pq, schemaMap)
 
 	// Extract JOIN relationships with schema awareness
 	result.JoinRelationships = extractJoinRelationshipsWithSchema(pq, schemaMap)

--- a/analysis/combined_extractor_test.go
+++ b/analysis/combined_extractor_test.go
@@ -242,6 +242,29 @@ func TestExtractQueryAnalysisWithSchema(t *testing.T) {
 	}
 }
 
+// TestExtractQueryAnalysisWithSchema_UnqualifiedWhereColumn verifies the combined
+// extractor resolves unqualified WHERE columns via the schema map.
+func TestExtractQueryAnalysisWithSchema_UnqualifiedWhereColumn(t *testing.T) {
+	query := "SELECT * FROM orders o JOIN customers c ON o.customer_id = c.id WHERE total > 100"
+
+	schemaMap := map[string][]ColumnSchema{
+		"customers": {
+			{Name: "id", PGType: "bigint", IsPrimaryKey: true},
+		},
+		"orders": {
+			{Name: "id", PGType: "bigint", IsPrimaryKey: true},
+			{Name: "customer_id", PGType: "bigint"},
+			{Name: "total", PGType: "numeric"},
+		},
+	}
+
+	result, err := ExtractQueryAnalysisWithSchema(query, schemaMap)
+	require.NoError(t, err)
+	require.Len(t, result.WhereConditions, 1)
+	assert.Equal(t, "orders", result.WhereConditions[0].Table)
+	assert.Equal(t, "total", result.WhereConditions[0].Column)
+}
+
 // =============================================================================
 // isColumnPrimaryKey Tests
 // =============================================================================

--- a/analysis/where_conditions.go
+++ b/analysis/where_conditions.go
@@ -59,12 +59,26 @@ var jsonbOperators = map[string]bool{
 // Returns a list of conditions with table, column, operator, and value information.
 // Supports all standard SQL operators: =, !=, <>, >, <, >=, <=, BETWEEN, IN, LIKE, IS NULL, etc.
 // Also supports JSONB operators (@>, ?, ?|, ?&) and extraction patterns.
+//
+// In multi-table queries, unqualified columns leave WhereCondition.Table empty.
+// Use ExtractWhereConditionsWithSchema to resolve them via schema metadata.
 func ExtractWhereConditions(query string) ([]WhereCondition, error) {
+	return ExtractWhereConditionsWithSchema(query, nil)
+}
+
+// ExtractWhereConditionsWithSchema is like ExtractWhereConditions, but resolves
+// the table of unqualified columns in multi-table queries via schema metadata:
+// if exactly one of the query's base tables contains the column, that table is
+// used; zero or multiple matches leave Table empty.
+// The schemaMap is keyed by lowercase table name (same shape as
+// ExtractJoinRelationshipsWithSchema). A nil schemaMap behaves exactly like
+// ExtractWhereConditions.
+func ExtractWhereConditionsWithSchema(query string, schemaMap map[string][]ColumnSchema) ([]WhereCondition, error) {
 	pq, err := postgresparser.ParseSQL(query)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse query: %w", err)
 	}
-	return extractWhereConditionsFromParsed(pq), nil
+	return extractWhereConditionsFromParsed(pq, schemaMap), nil
 }
 
 // jsonbInfo holds extracted JSONB operator information.

--- a/analysis/where_conditions_test.go
+++ b/analysis/where_conditions_test.go
@@ -1038,6 +1038,98 @@ func TestExtractWhereConditions_TableResolution(t *testing.T) {
 	}
 }
 
+// TestExtractWhereConditionsWithSchema verifies schema-based table resolution
+// for unqualified columns in multi-table queries.
+func TestExtractWhereConditionsWithSchema(t *testing.T) {
+	schemaMap := map[string][]ColumnSchema{
+		"orders": {
+			{Name: "id", PGType: "integer", IsPrimaryKey: true},
+			{Name: "customer_id", PGType: "integer"},
+			{Name: "total", PGType: "numeric"},
+			{Name: "created_at", PGType: "timestamptz"},
+		},
+		"customers": {
+			{Name: "id", PGType: "integer", IsPrimaryKey: true},
+			{Name: "country", PGType: "text"},
+			{Name: "created_at", PGType: "timestamptz"},
+		},
+	}
+
+	tests := []struct {
+		name           string
+		query          string
+		expectedTable  string
+		expectedColumn string
+	}{
+		{
+			// Exact case from issue #75.
+			name: "unqualified column resolved via schema",
+			query: `SELECT *
+FROM orders o
+JOIN customers c ON o.customer_id = c.id
+WHERE total > 100`,
+			expectedTable:  "orders",
+			expectedColumn: "total",
+		},
+		{
+			name:           "column in both tables stays unresolved",
+			query:          "SELECT * FROM orders o JOIN customers c ON o.customer_id = c.id WHERE created_at > '2026-01-01'",
+			expectedTable:  "",
+			expectedColumn: "created_at",
+		},
+		{
+			name:           "column in neither table stays unresolved",
+			query:          "SELECT * FROM orders o JOIN customers c ON o.customer_id = c.id WHERE missing_col = 1",
+			expectedTable:  "",
+			expectedColumn: "missing_col",
+		},
+		{
+			name:           "qualified column keeps alias resolution",
+			query:          "SELECT * FROM orders o JOIN customers c ON o.customer_id = c.id WHERE c.country = 'US'",
+			expectedTable:  "customers",
+			expectedColumn: "country",
+		},
+		{
+			name:           "single-table fallback still applies without schema entry",
+			query:          "SELECT * FROM payments WHERE amount > 5",
+			expectedTable:  "payments",
+			expectedColumn: "amount",
+		},
+		{
+			name:           "self-join resolves to the shared table",
+			query:          "SELECT * FROM orders a JOIN orders b ON a.id = b.id WHERE total > 100",
+			expectedTable:  "orders",
+			expectedColumn: "total",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conditions, err := ExtractWhereConditionsWithSchema(tt.query, schemaMap)
+
+			require.NoError(t, err)
+			require.Len(t, conditions, 1)
+			assert.Equal(t, tt.expectedTable, conditions[0].Table)
+			assert.Equal(t, tt.expectedColumn, conditions[0].Column)
+		})
+	}
+}
+
+// TestExtractWhereConditionsWithSchema_NilSchema verifies a nil schemaMap
+// behaves exactly like ExtractWhereConditions.
+func TestExtractWhereConditionsWithSchema_NilSchema(t *testing.T) {
+	query := "SELECT * FROM orders o JOIN customers c ON o.customer_id = c.id WHERE total > 100"
+
+	withSchema, err := ExtractWhereConditionsWithSchema(query, nil)
+	require.NoError(t, err)
+	plain, err := ExtractWhereConditions(query)
+	require.NoError(t, err)
+
+	assert.Equal(t, plain, withSchema)
+	require.Len(t, withSchema, 1)
+	assert.Empty(t, withSchema[0].Table)
+}
+
 // TestBuildWhereAliasMap verifies WHERE alias-map resolution behavior.
 func TestBuildWhereAliasMap(t *testing.T) {
 	tables := []postgresparser.TableRef{

--- a/docs/architecture-decision-guide.md
+++ b/docs/architecture-decision-guide.md
@@ -103,7 +103,7 @@ Not in core IR. Here's why:
 3. This logic is policy. It evolves independently from parse-tree extraction.
 4. Keeping it out of core avoids penalizing callers who only need IR.
 
-Same logic applies to `ExtractJoinRelationshipsWithSchema` and `ExtractQueryAnalysisWithSchema` — they accept `map[string][]ColumnSchema` (external metadata the grammar can't provide). Core's contract is "SQL text in, IR out, no side inputs."
+Same logic applies to `ExtractWhereConditionsWithSchema`, `ExtractJoinRelationshipsWithSchema`, and `ExtractQueryAnalysisWithSchema` — they accept `map[string][]ColumnSchema` (external metadata the grammar can't provide). Core's contract is "SQL text in, IR out, no side inputs."
 
 ## Anti-Patterns
 


### PR DESCRIPTION
## Summary

- New `analysis.ExtractWhereConditionsWithSchema(query, schemaMap)` resolves the owning table of unqualified columns in multi-table queries. The column is looked up across the query's base tables in the schema map: exactly one match resolves to that table, zero or multiple matches leave `Table` empty.
- `ExtractWhereConditions` now delegates with a nil map — output unchanged.
- `ExtractQueryAnalysisWithSchema` passes its schema map through, so its `WhereConditions` gain the same resolution.
- The lookup only runs when alias resolution fails in a multi-table query, so the existing fast path is untouched.

## Layer

- [ ] Parser IR
- [x] Analysis layer (`analysis/where_conditions.go`, `analysis/combined_extractor.go`)
- [x] Tests
- [x] Documentation

## SQL examples

The example from the issue:

```sql
SELECT *
FROM orders o
JOIN customers c ON o.customer_id = c.id
WHERE total > 100;
```

With a schema map where only `orders` has a `total` column:

- `WhereCondition{Table: "orders", Column: "total", Operator: ">", Value: "100"}`

Without schema (or with the column present in both tables), `Table` stays empty — no guessing.

## Test plan

- [x] New `TestExtractWhereConditionsWithSchema` covering: the issue's query verbatim, ambiguous column (in both tables), unknown column, qualified columns keeping alias resolution, single-table fallback, and self-joins.
- [x] New `TestExtractWhereConditionsWithSchema_NilSchema` asserting nil-map output is identical to `ExtractWhereConditions`.
- [x] New `TestExtractQueryAnalysisWithSchema_UnqualifiedWhereColumn` for the combined extractor.
- [x] `go test -race -count=1 ./...` passes (all packages)
- [x] `make vet` clean, `golangci-lint run` — 0 issues
- [x] Downstream valk modules (libs/common, libs/valk-sim, anomaly-detector, simulation-engine) build and their unit tests pass against this branch.

## Behavioral impact

Additive only. `ExtractWhereConditions` output is byte-identical (covered by a dedicated test). The only behavior change is in `ExtractQueryAnalysisWithSchema`, which can now populate `Table` values that were previously empty strings — and only when the caller supplies schema metadata.

## Out of scope

- Resolving columns that originate from CTEs or subqueries — schema resolution considers base tables only.
- Erroring on ambiguity: a valid query cannot reference an ambiguous unqualified column, so multiple matches indicate stale schema metadata and resolve to empty rather than failing the whole extraction.

## Related issues

Closes #75

## Checklist

- [x] No changes to `gen/` (auto-generated ANTLR code)
- [x] No public API signature changes (new function only)
- [x] Schema metadata reuses the existing `map[string][]ColumnSchema` shape
- [x] Documentation updated (README, architecture guide)
