### PR TITLE
feat(ir): tag subqueries with the clause they appear in

### DIFF
--- a/analysis/analysis.go
+++ b/analysis/analysis.go
@@ -248,8 +248,9 @@ func convertSubqueries(subs []postgresparser.SubqueryRef) []SQLSubquery {
 	out := make([]SQLSubquery, 0, len(subs))
 	for _, s := range subs {
 		out = append(out, SQLSubquery{
-			Alias:    s.Alias,
-			Analysis: convertParsedQuery(s.Query),
+			Alias:        s.Alias,
+			SourceClause: s.SourceClause,
+			Analysis:     convertParsedQuery(s.Query),
 		})
 	}
 	return out
@@ -382,8 +383,9 @@ func convertMerge(merge *postgresparser.MergeClause) *SQLMerge {
 	}
 	if merge.Source.Subquery != nil {
 		out.Source.Subquery = &SQLSubquery{
-			Alias:    merge.Source.Subquery.Alias,
-			Analysis: convertParsedQuery(merge.Source.Subquery.Query),
+			Alias:        merge.Source.Subquery.Alias,
+			SourceClause: merge.Source.Subquery.SourceClause,
+			Analysis:     convertParsedQuery(merge.Source.Subquery.Query),
 		}
 	}
 	return out

--- a/analysis/analysis_edge_cases_test.go
+++ b/analysis/analysis_edge_cases_test.go
@@ -427,6 +427,15 @@ func TestAnalyzeInsertMultipleValues(t *testing.T) {
 	assert.Contains(t, result.Returning, "name")
 }
 
+// TestAnalyzeSubquerySourceClause verifies the analysis DTO carries the
+// clause each subquery was found in.
+func TestAnalyzeSubquerySourceClause(t *testing.T) {
+	result, err := AnalyzeSQL(`SELECT * FROM t0 WHERE EXISTS (SELECT 1 FROM t1 WHERE t1.x = t0.id)`)
+	require.NoError(t, err)
+	require.Len(t, result.Subqueries, 1)
+	assert.Equal(t, "WHERE", result.Subqueries[0].SourceClause)
+}
+
 // Helper function
 func contains(slice []string, item string) bool {
 	for _, s := range slice {

--- a/analysis/types.go
+++ b/analysis/types.go
@@ -137,8 +137,11 @@ type SQLSetOperation struct {
 
 // SQLSubquery references a derived table; Analysis may be nil if omitted.
 type SQLSubquery struct {
-	Alias    string
-	Analysis *SQLAnalysis
+	Alias string
+	// SourceClause is the clause the subquery was found in: "WHERE", "HAVING",
+	// "SELECT", "FROM", or "SETOP". Empty when the origin was not recorded.
+	SourceClause string
+	Analysis     *SQLAnalysis
 }
 
 // SQLCTE describes a common table expression.

--- a/docs/parsed-query.md
+++ b/docs/parsed-query.md
@@ -57,6 +57,9 @@ It is not designed for:
   - `ParsedQuery`: nested IR for the CTE body when the body is a supported preparable statement.
   - `Materialized`: materialization hint (`MATERIALIZED`, `NOT MATERIALIZED`, or empty).
 - `Subqueries`: Nested query refs discovered in the statement.
+  - `Alias`: binding name for FROM-clause derived tables (empty for expression subqueries).
+  - `SourceClause`: clause the subquery was found in (`WHERE`, `HAVING`, `SELECT`, `FROM`, or `SETOP`).
+  - `Query`: nested IR for the subquery body.
 - `JoinConditions`: Raw join condition expressions.
 - `Correlations`: Outer/inner alias correlation metadata for lateral/correlated subqueries.
 

--- a/helpers.go
+++ b/helpers.go
@@ -131,8 +131,9 @@ func findAndRecordUsage(result *ParsedQuery, ctx antlr.RuleContext, role ColumnU
 
 // extractExpressionSubqueries captures direct scalar subqueries in an
 // expression and stores them under result.Subqueries without flattening their
-// nested ColumnUsage into the parent query.
-func extractExpressionSubqueries(result *ParsedQuery, ctx antlr.RuleContext, tokens antlr.TokenStream) {
+// nested ColumnUsage into the parent query. clause is the enclosing clause the
+// expression belongs to (see SubqueryRef.SourceClause).
+func extractExpressionSubqueries(result *ParsedQuery, ctx antlr.RuleContext, clause string, tokens antlr.TokenStream) {
 	if result == nil || ctx == nil {
 		return
 	}
@@ -145,7 +146,7 @@ func extractExpressionSubqueries(result *ParsedQuery, ctx antlr.RuleContext, tok
 	collector := &expressionSubqueryCollector{BasePostgreSQLParserListener: &gen.BasePostgreSQLParserListener{}}
 	antlr.ParseTreeWalkerDefault.Walk(collector, tree)
 	for _, selectWithParens := range collector.subqueries {
-		subRef, err := buildSubqueryRef("", selectWithParens, tokens)
+		subRef, err := buildSubqueryRef("", clause, selectWithParens, tokens)
 		if err != nil || subRef == nil {
 			continue
 		}

--- a/ir.go
+++ b/ir.go
@@ -211,7 +211,10 @@ type DDLAction struct {
 // SubqueryRef records metadata for subqueries discovered in FROM or set operations.
 type SubqueryRef struct {
 	Alias string
-	Query *ParsedQuery
+	// SourceClause is the clause the subquery was found in: "WHERE", "HAVING",
+	// "SELECT", "FROM", or "SETOP". Empty when the origin was not recorded.
+	SourceClause string
+	Query        *ParsedQuery
 }
 
 // OrderExpression describes ORDER BY items.

--- a/merge.go
+++ b/merge.go
@@ -64,7 +64,7 @@ func populateMerge(result *ParsedQuery, ctx gen.IMergestmtContext, tokens antlr.
 		appendSetOpTables(result, nil, []TableRef{merge.Source.Table})
 		// Build nested subquery analysis without flattening inner column usage
 		// into the MERGE parent scope.
-		if subRef, err := buildSubqueryRef(sourceAlias, swp, tokens); err == nil && subRef != nil {
+		if subRef, err := buildSubqueryRef(sourceAlias, "FROM", swp, tokens); err == nil && subRef != nil {
 			merge.Source.Subquery = subRef
 			result.Subqueries = append(result.Subqueries, *subRef)
 			appendSetOpTables(result, nil, subRef.Query.Tables)

--- a/parser_ir_edge_cases_test.go
+++ b/parser_ir_edge_cases_test.go
@@ -88,6 +88,53 @@ WHERE sub.total_amount < 10000`
 	assert.Contains(t, sq.Query.GroupBy[0], "user_id", "expected subquery GROUP BY user_id")
 }
 
+// TestIR_SubquerySourceClause verifies each subquery records the clause it was
+// found in.
+func TestIR_SubquerySourceClause(t *testing.T) {
+	tests := []struct {
+		name       string
+		sql        string
+		wantClause string
+	}{
+		{
+			name:       "where exists",
+			sql:        `SELECT * FROM t0 WHERE EXISTS (SELECT 1 FROM t1 WHERE t1.x = t0.id)`,
+			wantClause: "WHERE",
+		},
+		{
+			name:       "select list scalar",
+			sql:        `SELECT id, (SELECT max(v) FROM t1) AS m FROM t0`,
+			wantClause: "SELECT",
+		},
+		{
+			name:       "from derived table",
+			sql:        `SELECT * FROM (SELECT id FROM t1) sub WHERE sub.id > 1`,
+			wantClause: "FROM",
+		},
+		{
+			name:       "having",
+			sql:        `SELECT c, count(*) FROM t0 GROUP BY c HAVING count(*) > (SELECT avg(n) FROM t1)`,
+			wantClause: "HAVING",
+		},
+		{
+			name:       "set operation branch",
+			sql:        `(SELECT a FROM t0) UNION (SELECT b FROM t1)`,
+			wantClause: "SETOP",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ir := parseAssertNoError(t, tt.sql)
+			require.NotEmpty(t, ir.Subqueries, "expected at least one subquery")
+			for _, sq := range ir.Subqueries {
+				assert.Equal(t, tt.wantClause, sq.SourceClause,
+					"subquery %q should record clause %s", sq.Query.RawSQL, tt.wantClause)
+			}
+		})
+	}
+}
+
 // ---------------------------------------------------------------------------
 // 2. Multiple CTEs referencing each other
 // ---------------------------------------------------------------------------

--- a/select.go
+++ b/select.go
@@ -238,7 +238,7 @@ func extractProjection(result *ParsedQuery, simple gen.ISimple_select_pramaryCon
 			if col.A_expr() != nil {
 				expr = text(tokens, col.A_expr())
 				findAndRecordUsage(result, col.A_expr(), ColumnUsageTypeProjection, tokens)
-				extractExpressionSubqueries(result, col.A_expr(), tokens)
+				extractExpressionSubqueries(result, col.A_expr(), "SELECT", tokens)
 			}
 			alias := ""
 			switch {
@@ -340,7 +340,7 @@ func collectTableRefs(result *ParsedQuery, ref gen.ITable_refContext, tokens ant
 		})
 		// Build nested subquery analysis without flattening inner column usage
 		// into the parent query scope.
-		if subRef, err := buildSubqueryRef(alias, sub, tokens); err == nil && subRef != nil {
+		if subRef, err := buildSubqueryRef(alias, "FROM", sub, tokens); err == nil && subRef != nil {
 			result.Subqueries = append(result.Subqueries, *subRef)
 			appendSetOpTables(result, nil, subRef.Query.Tables)
 		}
@@ -461,7 +461,7 @@ func extractWhereClause(result *ParsedQuery, whereCtx gen.IWhere_clauseContext, 
 		}
 		clauseText := strings.TrimSpace(ctxText(tokens, prc))
 		result.Where = append(result.Where, clauseText)
-		extractExpressionSubqueries(result, expr, tokens)
+		extractExpressionSubqueries(result, expr, "WHERE", tokens)
 		// WHERE: enable wrapper extraction.
 		findAndRecordComparisons(result, expr, ColumnUsageTypeFilter, tokens, true)
 	}
@@ -476,7 +476,7 @@ func extractHavingClause(result *ParsedQuery, havingCtx gen.IHaving_clauseContex
 		if clauseText := text(tokens, expr); clauseText != "" {
 			result.Having = append(result.Having, clauseText)
 		}
-		extractExpressionSubqueries(result, expr, tokens)
+		extractExpressionSubqueries(result, expr, "HAVING", tokens)
 		// HAVING: wrappers explicitly out of scope for v1 — pass false.
 		findAndRecordComparisons(result, expr, ColumnUsageTypeFilter, tokens, false)
 	}

--- a/setops.go
+++ b/setops.go
@@ -295,7 +295,7 @@ func extractTablesAndUsageForPrimary(primary gen.ISimple_select_pramaryContext, 
 	if primary.Select_with_parens() != nil {
 		// Build nested subquery analysis without flattening inner column usage
 		// into the parent query scope.
-		if subRef, err := buildSubqueryRef("", primary.Select_with_parens(), tokens); err == nil && subRef != nil {
+		if subRef, err := buildSubqueryRef("", "SETOP", primary.Select_with_parens(), tokens); err == nil && subRef != nil {
 			tmp.Subqueries = append(tmp.Subqueries, *subRef)
 			tmp.Tables = append(tmp.Tables, subRef.Query.Tables...)
 		}
@@ -304,7 +304,8 @@ func extractTablesAndUsageForPrimary(primary gen.ISimple_select_pramaryContext, 
 }
 
 // buildSubqueryRef parses a parenthesised subquery into nested IR.
-func buildSubqueryRef(alias string, selectWithParens gen.ISelect_with_parensContext, tokens antlr.TokenStream) (*SubqueryRef, error) {
+// sourceClause records the clause the subquery was found in (see SubqueryRef.SourceClause).
+func buildSubqueryRef(alias, sourceClause string, selectWithParens gen.ISelect_with_parensContext, tokens antlr.TokenStream) (*SubqueryRef, error) {
 	if selectWithParens == nil {
 		return nil, nil
 	}
@@ -327,8 +328,9 @@ func buildSubqueryRef(alias string, selectWithParens gen.ISelect_with_parensCont
 	}
 
 	return &SubqueryRef{
-		Alias: alias,
-		Query: parsed,
+		Alias:        alias,
+		SourceClause: sourceClause,
+		Query:        parsed,
 	}, nil
 }
 


### PR DESCRIPTION
## Summary

- New `SourceClause` field on `SubqueryRef` (IR) and `SQLSubquery` (analysis DTO) records the clause each subquery was found in: `WHERE`, `HAVING`, `SELECT`, `FROM`, or `SETOP`.
- The three expression-subquery sites in `select.go` already know their clause (SELECT-list / WHERE / HAVING), so the clause is threaded through `extractExpressionSubqueries` and `buildSubqueryRef` rather than inferred from the parse tree.
- FROM derived tables, the MERGE `USING` source, and set-operation branches each pass their clause literal at the call site.

## Layer

- [x] Parser IR (`ir.go`, `setops.go`, `helpers.go`, `select.go`, `merge.go`)
- [x] Analysis layer (`analysis/types.go`, `analysis/analysis.go`)
- [x] Tests
- [x] Documentation

## SQL examples

```sql
SELECT * FROM t0 WHERE EXISTS (SELECT 1 FROM t1 WHERE t1.x = t0.id);
-- Subqueries[0].SourceClause == "WHERE"

SELECT id, (SELECT max(v) FROM t1) AS m FROM t0;
-- Subqueries[0].SourceClause == "SELECT"

SELECT * FROM (SELECT id FROM t1) sub WHERE sub.id > 1;
-- Subqueries[0].SourceClause == "FROM"

SELECT c, count(*) FROM t0 GROUP BY c HAVING count(*) > (SELECT avg(n) FROM t1);
-- Subqueries[0].SourceClause == "HAVING"

(SELECT a FROM t0) UNION (SELECT b FROM t1);
-- both branches: SourceClause == "SETOP"
```

This resolves the gap noted in #74: a WHERE-clause `EXISTS` subquery can now be distinguished from a FROM derived table without substring-matching `RawSQL`.

## Test plan

- [x] New `TestIR_SubquerySourceClause`, table-driven over all five clause types (incl. the #74 EXISTS-in-WHERE case).
- [x] New `TestAnalyzeSubquerySourceClause` confirming the analysis DTO carries the value.
- [x] `go test -race -count=1 ./...` passes (all packages)
- [x] `make vet` clean, `golangci-lint run` - 0 issues

## Behavioral impact

Additive only. `SourceClause` is empty for any consumer that does not read it; no existing field or output changes. `buildSubqueryRef` gained a parameter, but it is unexported.

## Out of scope

- Emitting a structured `EXISTS` / `IN (subquery)` marker in `WhereCondition` that references the subquery. That is a separate decision; this PR only records where each subquery came from.

## Related issues

Closes #78 (follow-up to #74).

## Checklist

- [x] No changes to `gen/` (auto-generated ANTLR code)
- [x] No exported signature changes (new struct fields only)
- [x] Documentation updated (`docs/parsed-query.md`)
