### PR TITLE
feat(analysis): resolve unqualified WHERE columns against CTEs and derived tables

### DIFF
--- a/analysis/combined_extractor.go
+++ b/analysis/combined_extractor.go
@@ -61,9 +61,7 @@ func ExtractQueryAnalysis(query string) (*QueryAnalysisResult, error) {
 // by looking it up across the query's base tables in schemaMap. Returns the table
 // name when exactly one base table contains the column, "" otherwise.
 func resolveColumnTableFromSchema(column string, pq *postgresparser.ParsedQuery, schemaMap map[string][]ColumnSchema) string {
-	// A nil schemaMap opts out of resolution (the ExtractWhereConditions path).
-	// An empty but non-nil map still resolves CTE/derived relations, which do
-	// not need base-table schema metadata.
+	// nil opts out of resolution; an empty map still resolves CTE/derived relations.
 	if schemaMap == nil {
 		return ""
 	}
@@ -75,8 +73,6 @@ func resolveColumnTableFromSchema(column string, pq *postgresparser.ParsedQuery,
 	match := ""
 	matched := false
 	for _, table := range pq.Tables {
-		// Only the query's own FROM relations are candidates, not tables
-		// surfaced from inside a CTE or subquery body.
 		if table.Nested {
 			continue
 		}
@@ -85,8 +81,7 @@ func resolveColumnTableFromSchema(column string, pq *postgresparser.ParsedQuery,
 			continue
 		}
 		if matched && name != match {
-			// The column exists in more than one distinct direct relation.
-			// Repeats of the same relation (self-joins) resolve to the shared name.
+			// Distinct relations only; self-joins resolve to the shared name.
 			return ""
 		}
 		match = name

--- a/analysis/combined_extractor.go
+++ b/analysis/combined_extractor.go
@@ -60,8 +60,11 @@ func ExtractQueryAnalysis(query string) (*QueryAnalysisResult, error) {
 // resolveColumnTableFromSchema resolves an unqualified column to its owning table
 // by looking it up across the query's base tables in schemaMap. Returns the table
 // name when exactly one base table contains the column, "" otherwise.
-func resolveColumnTableFromSchema(column string, tables []postgresparser.TableRef, schemaMap map[string][]ColumnSchema) string {
-	if len(schemaMap) == 0 {
+func resolveColumnTableFromSchema(column string, pq *postgresparser.ParsedQuery, schemaMap map[string][]ColumnSchema) string {
+	// A nil schemaMap opts out of resolution (the ExtractWhereConditions path).
+	// An empty but non-nil map still resolves CTE/derived relations, which do
+	// not need base-table schema metadata.
+	if schemaMap == nil {
 		return ""
 	}
 	col := strings.ToLower(ident.TrimQuotes(strings.TrimSpace(column)))
@@ -70,27 +73,183 @@ func resolveColumnTableFromSchema(column string, tables []postgresparser.TableRe
 	}
 
 	match := ""
-	for _, table := range tables {
-		if table.Type != postgresparser.TableTypeBase {
+	matched := false
+	for _, table := range pq.Tables {
+		// Only the query's own FROM relations are candidates, not tables
+		// surfaced from inside a CTE or subquery body.
+		if table.Nested {
 			continue
 		}
-		tableName := strings.ToLower(ident.TrimQuotes(strings.TrimSpace(table.Name)))
-		if tableName == "" || tableName == match {
+		name, contains := relationHasColumn(table, col, pq, schemaMap)
+		if name == "" || !contains {
 			continue
 		}
-		for _, cs := range schemaMap[tableName] {
-			if strings.ToLower(cs.Name) != col {
-				continue
-			}
-			if match != "" {
-				// Ambiguous: the column exists in more than one of the query's tables.
-				return ""
-			}
-			match = tableName
-			break
+		if matched && name != match {
+			// The column exists in more than one distinct direct relation.
+			// Repeats of the same relation (self-joins) resolve to the shared name.
+			return ""
 		}
+		match = name
+		matched = true
 	}
 	return match
+}
+
+// relationHasColumn reports whether a direct FROM relation exposes col, and
+// returns the relation's resolved name. Base tables are checked against
+// schemaMap; CTEs and derived tables against their own projection. A relation
+// projecting "*" cannot be enumerated and is treated as a possible owner.
+func relationHasColumn(table postgresparser.TableRef, col string, pq *postgresparser.ParsedQuery, schemaMap map[string][]ColumnSchema) (string, bool) {
+	switch table.Type {
+	case postgresparser.TableTypeBase:
+		name := strings.ToLower(ident.TrimQuotes(strings.TrimSpace(table.Name)))
+		if name == "" {
+			return "", false
+		}
+		for _, cs := range schemaMap[name] {
+			if strings.ToLower(cs.Name) == col {
+				return name, true
+			}
+		}
+		return name, false
+	case postgresparser.TableTypeCTE:
+		name := strings.ToLower(ident.TrimQuotes(strings.TrimSpace(table.Name)))
+		cols, star := cteProjection(pq, name)
+		return name, star || cols[col]
+	case postgresparser.TableTypeSubquery:
+		alias := strings.ToLower(ident.TrimQuotes(strings.TrimSpace(table.Name)))
+		cols, star := subqueryProjection(pq, alias)
+		return alias, star || cols[col]
+	default:
+		return "", false
+	}
+}
+
+// cteProjection returns the lowercased output column names of the named CTE and
+// whether they cannot be fully enumerated (a "*" projection).
+func cteProjection(pq *postgresparser.ParsedQuery, name string) (map[string]bool, bool) {
+	for _, cte := range pq.CTEs {
+		if strings.ToLower(ident.TrimQuotes(strings.TrimSpace(cte.Name))) != name {
+			continue
+		}
+		var projection []postgresparser.SelectColumn
+		if cte.ParsedQuery != nil {
+			projection = projectionOrReturning(cte.ParsedQuery)
+		}
+		return exposedColumns(projection, cte.ColumnAliases)
+	}
+	return nil, false
+}
+
+// subqueryProjection returns the lowercased output column names of the FROM
+// subquery with the given alias and whether they cannot be fully enumerated.
+func subqueryProjection(pq *postgresparser.ParsedQuery, alias string) (map[string]bool, bool) {
+	for _, sub := range pq.Subqueries {
+		if sub.SourceClause != "FROM" {
+			continue
+		}
+		if strings.ToLower(ident.TrimQuotes(strings.TrimSpace(sub.Alias))) != alias {
+			continue
+		}
+		var projection []postgresparser.SelectColumn
+		if sub.Query != nil {
+			projection = sub.Query.Columns
+		}
+		return exposedColumns(projection, sub.ColumnAliases)
+	}
+	return nil, false
+}
+
+// exposedColumns returns the lowercased output column names a relation exposes,
+// and whether they cannot be fully enumerated. A column alias list renames the
+// leading projected columns positionally; columns beyond the list keep their
+// own names. A "*" projection expands to an unknown set, so the relation is
+// opaque (treated as a possible owner of any column).
+func exposedColumns(projection []postgresparser.SelectColumn, aliasList []string) (map[string]bool, bool) {
+	if len(projection) == 0 {
+		// No enumerable projection (e.g. unparsed body); fall back to any
+		// declared alias list.
+		return lowerSet(aliasList), false
+	}
+
+	names := make(map[string]bool, len(projection))
+	for i, c := range projection {
+		expr := strings.TrimSpace(c.Expression)
+		if expr == "*" || strings.HasSuffix(expr, ".*") {
+			return names, true
+		}
+		name := ""
+		switch {
+		case i < len(aliasList):
+			name = aliasList[i]
+		case c.Alias != "":
+			name = c.Alias
+		default:
+			name = simpleColumnName(expr)
+		}
+		if name = strings.ToLower(ident.TrimQuotes(strings.TrimSpace(name))); name != "" {
+			names[name] = true
+		}
+	}
+	return names, false
+}
+
+// lowerSet builds a lowercased, unquoted lookup set from identifiers.
+func lowerSet(values []string) map[string]bool {
+	out := make(map[string]bool, len(values))
+	for _, v := range values {
+		if key := strings.ToLower(ident.TrimQuotes(strings.TrimSpace(v))); key != "" {
+			out[key] = true
+		}
+	}
+	return out
+}
+
+// projectionOrReturning returns the columns a relation exposes: the SELECT
+// projection, or the RETURNING list for a data-modifying CTE body.
+func projectionOrReturning(pq *postgresparser.ParsedQuery) []postgresparser.SelectColumn {
+	if len(pq.Columns) > 0 || len(pq.Returning) == 0 {
+		return pq.Columns
+	}
+	items := normalizeReturning(pq.Returning)
+	cols := make([]postgresparser.SelectColumn, 0, len(items))
+	for _, item := range items {
+		expr, alias := splitAsAlias(item)
+		cols = append(cols, postgresparser.SelectColumn{Expression: expr, Alias: alias})
+	}
+	return cols
+}
+
+// splitAsAlias splits a projection item into expression and output alias,
+// handling both "expr AS alias" and the implicit "expr alias" form. The
+// implicit form is only honored when the item is exactly two bare identifiers,
+// to avoid misreading expressions like "total + 1".
+func splitAsAlias(item string) (expr, alias string) {
+	item = strings.TrimSpace(item)
+	if idx := strings.LastIndex(strings.ToLower(item), " as "); idx >= 0 {
+		return strings.TrimSpace(item[:idx]), strings.TrimSpace(item[idx+4:])
+	}
+	if fields := strings.Fields(item); len(fields) == 2 && simpleColumnName(fields[0]) != "" && simpleColumnName(fields[1]) != "" {
+		return fields[0], fields[1]
+	}
+	return item, ""
+}
+
+// simpleColumnName returns the lowercased final identifier of a simple column
+// reference (e.g. "o.amount" -> "amount", "total" -> "total"). It returns ""
+// for computed expressions (functions, arithmetic, casts) whose output column
+// name cannot be derived from the text.
+func simpleColumnName(expr string) string {
+	// A trailing ::type cast keeps the underlying column's name (total::numeric
+	// is exposed as total), so drop the cast before inspecting the reference.
+	if i := strings.Index(expr, "::"); i >= 0 {
+		expr = strings.TrimSpace(expr[:i])
+	}
+	if expr == "" || strings.ContainsAny(expr, "()[] +-*/:") {
+		return ""
+	}
+	parts := strings.Split(expr, ".")
+	return strings.ToLower(ident.TrimQuotes(strings.TrimSpace(parts[len(parts)-1])))
 }
 
 // extractWhereConditionsFromParsed extracts WHERE conditions from an already-parsed query.
@@ -126,7 +285,7 @@ func extractWhereConditionsFromParsed(pq *postgresparser.ParsedQuery, schemaMap 
 				// No alias and no resolution - default to first table only for single-table queries
 				tableName = pq.Tables[0].Name
 			} else {
-				tableName = resolveColumnTableFromSchema(usage.Column, pq.Tables, schemaMap)
+				tableName = resolveColumnTableFromSchema(usage.Column, pq, schemaMap)
 			}
 		}
 

--- a/analysis/where_conditions.go
+++ b/analysis/where_conditions.go
@@ -67,9 +67,10 @@ func ExtractWhereConditions(query string) ([]WhereCondition, error) {
 }
 
 // ExtractWhereConditionsWithSchema is like ExtractWhereConditions, but resolves
-// the table of unqualified columns in multi-table queries via schema metadata:
-// if exactly one of the query's base tables contains the column, that table is
-// used; zero or multiple matches leave Table empty.
+// the table of unqualified columns in multi-table queries. A column is matched
+// against the query's direct FROM relations: base tables via schemaMap, and CTEs
+// or derived tables via their own projection. If exactly one relation exposes
+// the column, that relation is used; zero or multiple matches leave Table empty.
 // The schemaMap is keyed by lowercase table name (same shape as
 // ExtractJoinRelationshipsWithSchema). A nil schemaMap behaves exactly like
 // ExtractWhereConditions.

--- a/analysis/where_conditions_test.go
+++ b/analysis/where_conditions_test.go
@@ -1115,6 +1115,125 @@ WHERE total > 100`,
 	}
 }
 
+// TestExtractWhereConditionsWithSchema_CTEAndDerived verifies unqualified WHERE
+// columns resolve against CTE and derived-table projections, and are not
+// misattributed to base tables flattened in from inside those bodies (issue #77).
+func TestExtractWhereConditionsWithSchema_CTEAndDerived(t *testing.T) {
+	schemaMap := map[string][]ColumnSchema{
+		"orders": {
+			{Name: "id", IsPrimaryKey: true},
+			{Name: "customer_id"},
+			{Name: "total"},
+		},
+		"customers": {
+			{Name: "id", IsPrimaryKey: true},
+			{Name: "country"},
+		},
+	}
+
+	tests := []struct {
+		name          string
+		query         string
+		expectedTable string
+	}{
+		{
+			// total is projected by the CTE; the base "orders" inside the CTE body
+			// must not steal the attribution.
+			name: "column resolves to CTE, not nested base table",
+			query: `WITH recent_orders AS (SELECT id, customer_id, total FROM orders)
+SELECT * FROM recent_orders r JOIN customers c ON c.id = r.customer_id WHERE total > 100`,
+			expectedTable: "recent_orders",
+		},
+		{
+			name:          "column resolves to derived table projection",
+			query:         `SELECT * FROM (SELECT id, total FROM orders) sub JOIN customers c ON c.id = sub.id WHERE total > 100`,
+			expectedTable: "sub",
+		},
+		{
+			name:          "aliased projection column resolves to the CTE",
+			query:         `WITH t AS (SELECT o.amount AS total FROM orders o) SELECT * FROM t JOIN customers c ON c.id = 1 WHERE total > 1`,
+			expectedTable: "t",
+		},
+		{
+			// total exists in the CTE projection and a directly-joined base table.
+			name:          "collision between CTE and base table stays unresolved",
+			query:         `WITH t AS (SELECT total FROM orders) SELECT * FROM t JOIN orders o ON o.id = 1 WHERE total > 1`,
+			expectedTable: "",
+		},
+		{
+			name:          "SELECT star CTE alone resolves opaquely",
+			query:         `WITH t AS (SELECT * FROM orders) SELECT * FROM t WHERE total > 1`,
+			expectedTable: "t",
+		},
+		{
+			// SELECT * relation is opaque, so a column also present in a base table
+			// is ambiguous.
+			name:          "SELECT star CTE with base table is ambiguous",
+			query:         `WITH t AS (SELECT * FROM orders) SELECT * FROM t JOIN customers c ON c.id = 1 WHERE country = 'US'`,
+			expectedTable: "",
+		},
+		{
+			name:          "CTE column alias list exposes declared name",
+			query:         `WITH t(x) AS (SELECT total FROM orders) SELECT * FROM t JOIN customers c ON c.id = 1 WHERE x > 1`,
+			expectedTable: "t",
+		},
+		{
+			name:          "CTE column alias list hides inner column name",
+			query:         `WITH t(x) AS (SELECT total FROM orders) SELECT * FROM t JOIN customers c ON c.id = 1 WHERE total > 1`,
+			expectedTable: "",
+		},
+		{
+			name:          "derived table column alias list exposes declared name",
+			query:         `SELECT * FROM (SELECT total FROM orders) AS sub(x) JOIN customers c ON c.id = 1 WHERE x > 1`,
+			expectedTable: "sub",
+		},
+		{
+			name:          "derived table column alias list hides inner column name",
+			query:         `SELECT * FROM (SELECT total FROM orders) AS sub(x) JOIN customers c ON c.id = 1 WHERE total > 1`,
+			expectedTable: "",
+		},
+		{
+			// A short alias list renames only the leading column; the rest keep
+			// their projected names, so customer_id remains exposed by t.
+			name:          "short alias list keeps trailing projected columns",
+			query:         `WITH t(x) AS (SELECT total, customer_id FROM orders) SELECT * FROM t JOIN customers c ON c.id = 1 WHERE customer_id = 1`,
+			expectedTable: "t",
+		},
+		{
+			// total::numeric is still exposed as total.
+			name:          "casted projection column keeps its name",
+			query:         `WITH t AS (SELECT total::numeric, id FROM orders) SELECT * FROM t JOIN customers c ON c.id = 1 WHERE total > 1`,
+			expectedTable: "t",
+		},
+		{
+			name:          "data-modifying CTE exposes RETURNING columns",
+			query:         `WITH t AS (UPDATE orders SET total = total + 1 RETURNING id, total) SELECT * FROM t JOIN customers c ON c.id = 1 WHERE total > 1`,
+			expectedTable: "t",
+		},
+		{
+			name:          "RETURNING implicit alias is exposed",
+			query:         `WITH t AS (UPDATE orders SET total = total + 1 RETURNING total new_total) SELECT * FROM t JOIN customers c ON c.id = 1 WHERE new_total > 1`,
+			expectedTable: "t",
+		},
+		{
+			// A subquery body re-reading a directly-joined table must not disturb
+			// resolution: the direct base relation still owns the column.
+			name:          "direct table resolves despite same table inside a subquery",
+			query:         `SELECT * FROM orders, (SELECT id FROM orders) sub JOIN customers c ON c.id = 1 WHERE total > 1`,
+			expectedTable: "orders",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conditions, err := ExtractWhereConditionsWithSchema(tt.query, schemaMap)
+			require.NoError(t, err)
+			require.Len(t, conditions, 1)
+			assert.Equal(t, tt.expectedTable, conditions[0].Table)
+		})
+	}
+}
+
 // TestExtractWhereConditionsWithSchema_NilSchema verifies a nil schemaMap
 // behaves exactly like ExtractWhereConditions.
 func TestExtractWhereConditionsWithSchema_NilSchema(t *testing.T) {
@@ -1128,6 +1247,18 @@ func TestExtractWhereConditionsWithSchema_NilSchema(t *testing.T) {
 	assert.Equal(t, plain, withSchema)
 	require.Len(t, withSchema, 1)
 	assert.Empty(t, withSchema[0].Table)
+}
+
+// TestExtractWhereConditionsWithSchema_EmptyMapResolvesProjections verifies an
+// empty (non-nil) schema map still resolves CTE/derived relations, which do not
+// need base-table schema metadata.
+func TestExtractWhereConditionsWithSchema_EmptyMapResolvesProjections(t *testing.T) {
+	query := `WITH t AS (SELECT x FROM src) SELECT * FROM t JOIN other o ON o.id = 1 WHERE x = 1`
+
+	conditions, err := ExtractWhereConditionsWithSchema(query, map[string][]ColumnSchema{})
+	require.NoError(t, err)
+	require.Len(t, conditions, 1)
+	assert.Equal(t, "t", conditions[0].Table)
 }
 
 // TestBuildWhereAliasMap verifies WHERE alias-map resolution behavior.

--- a/dml_delete.go
+++ b/dml_delete.go
@@ -19,7 +19,7 @@ func populateDelete(result *ParsedQuery, ctx gen.IDeletestmtContext, tokens antl
 		if withCtx := ctx.With_clause_().With_clause(); withCtx != nil {
 			ctes, cteTables := extractCTEs(withCtx, tokens)
 			result.CTEs = append(result.CTEs, ctes...)
-			result.Tables = append(result.Tables, cteTables...)
+			result.Tables = append(result.Tables, markNested(cteTables)...)
 		}
 	}
 	cteNames := buildCTENameSet(result.CTEs)

--- a/dml_insert.go
+++ b/dml_insert.go
@@ -20,7 +20,7 @@ func populateInsert(result *ParsedQuery, ctx gen.IInsertstmtContext, tokens antl
 		if withCtx := ctx.With_clause_().With_clause(); withCtx != nil {
 			ctes, cteTables := extractCTEs(withCtx, tokens)
 			result.CTEs = append(result.CTEs, ctes...)
-			result.Tables = append(result.Tables, cteTables...)
+			result.Tables = append(result.Tables, markNested(cteTables)...)
 		}
 	}
 	if target := ctx.Insert_target(); target != nil {

--- a/dml_update.go
+++ b/dml_update.go
@@ -19,7 +19,7 @@ func populateUpdate(result *ParsedQuery, ctx gen.IUpdatestmtContext, tokens antl
 		if withCtx := ctx.With_clause_().With_clause(); withCtx != nil {
 			ctes, cteTables := extractCTEs(withCtx, tokens)
 			result.CTEs = append(result.CTEs, ctes...)
-			result.Tables = append(result.Tables, cteTables...)
+			result.Tables = append(result.Tables, markNested(cteTables)...)
 		}
 	}
 	cteNames := buildCTENameSet(result.CTEs)

--- a/docs/parsed-query.md
+++ b/docs/parsed-query.md
@@ -50,7 +50,7 @@ It is not designed for:
 
 ## Relation Metadata
 
-- `Tables`: Structured relation refs (`Schema`, `Name`, `Alias`, `Type`, `Raw`).
+- `Tables`: Structured relation refs (`Schema`, `Name`, `Alias`, `Type`, `Raw`). `Nested` is true for relations surfaced from inside a CTE or subquery body rather than the query's own FROM.
 - `CTEs`: `WITH` definitions.
   - `Name`: CTE binding name.
   - `Query`: raw SQL text of the CTE body.

--- a/helpers.go
+++ b/helpers.go
@@ -239,6 +239,35 @@ func tableRefAliasOrName(tr TableRef) string {
 	return strings.TrimSpace(tr.Raw)
 }
 
+// nameListStrings returns the trimmed identifiers of a name_list (e.g. the
+// column alias list in WITH t(a, b) or (SELECT ...) sub(a, b)).
+func nameListStrings(nl gen.IName_listContext, tokens antlr.TokenStream) []string {
+	if nl == nil {
+		return nil
+	}
+	names := nl.AllName()
+	out := make([]string, 0, len(names))
+	for _, n := range names {
+		if name := strings.TrimSpace(text(tokens, n)); name != "" {
+			out = append(out, name)
+		}
+	}
+	return out
+}
+
+// markNested returns a copy of tables with Nested set to true.
+func markNested(tables []TableRef) []TableRef {
+	if len(tables) == 0 {
+		return tables
+	}
+	out := make([]TableRef, len(tables))
+	for i, t := range tables {
+		t.Nested = true
+		out[i] = t
+	}
+	return out
+}
+
 // recordUsingJoinFromString parses a textual USING clause and records join usages for the two most recent base tables.
 func recordUsingJoinFromString(result *ParsedQuery, clause string) {
 	if result == nil {

--- a/ir.go
+++ b/ir.go
@@ -61,6 +61,9 @@ type TableRef struct {
 	Raw           string
 	JoinType      string // "INNER", "LEFT", "RIGHT", "FULL", "CROSS", "NATURAL", or "" for base FROM tables.
 	JoinCondition string // Raw ON/USING clause text, or "" for base/CROSS tables.
+	// Nested is true for relations surfaced from inside a CTE or subquery body,
+	// rather than this query's own FROM clause.
+	Nested bool
 }
 
 // SelectColumn captures the projection list of a SELECT query.
@@ -214,7 +217,10 @@ type SubqueryRef struct {
 	// SourceClause is the clause the subquery was found in: "WHERE", "HAVING",
 	// "SELECT", "FROM", or "SETOP". Empty when the origin was not recorded.
 	SourceClause string
-	Query        *ParsedQuery
+	// ColumnAliases holds the explicit output column names from a derived table
+	// alias list (SELECT ...) sub(a, b); empty when not declared.
+	ColumnAliases []string
+	Query         *ParsedQuery
 }
 
 // OrderExpression describes ORDER BY items.
@@ -355,6 +361,9 @@ type CTE struct {
 	Query        string
 	ParsedQuery  *ParsedQuery
 	Materialized string // "", "MATERIALIZED", or "NOT MATERIALIZED"
+	// ColumnAliases holds the explicit output column names from WITH name(a, b);
+	// empty when not declared (the projection in ParsedQuery applies).
+	ColumnAliases []string
 }
 
 // ColumnUsageType defines the context where a column is referenced.

--- a/merge.go
+++ b/merge.go
@@ -67,7 +67,7 @@ func populateMerge(result *ParsedQuery, ctx gen.IMergestmtContext, tokens antlr.
 		if subRef, err := buildSubqueryRef(sourceAlias, "FROM", swp, tokens); err == nil && subRef != nil {
 			merge.Source.Subquery = subRef
 			result.Subqueries = append(result.Subqueries, *subRef)
-			appendSetOpTables(result, nil, subRef.Query.Tables)
+			appendSetOpTables(result, nil, markNested(subRef.Query.Tables))
 		}
 	} else if len(qualifiedNames) > 1 {
 		sourceName := ""

--- a/parser_ir_cte_test.go
+++ b/parser_ir_cte_test.go
@@ -41,6 +41,54 @@ WHERE active_users.id = $2`
 	assert.True(t, foundFilter, "expected CTE parsed query to retain filter column usage")
 }
 
+// TestIR_NestedTableMarking verifies tables surfaced from CTE and subquery
+// bodies are marked Nested, while the query's own FROM relations are not.
+func TestIR_NestedTableMarking(t *testing.T) {
+	nestedOf := func(ir *ParsedQuery, name string) (bool, bool) {
+		for _, tbl := range ir.Tables {
+			if tbl.Name == name {
+				return tbl.Nested, true
+			}
+		}
+		return false, false
+	}
+
+	t.Run("CTE body table is nested, FROM relations are not", func(t *testing.T) {
+		ir := parseAssertNoError(t, `WITH ro AS (SELECT id FROM orders) SELECT * FROM ro JOIN customers c ON c.id = ro.id`)
+
+		nested, ok := nestedOf(ir, "orders")
+		require.True(t, ok, "expected nested base table 'orders'")
+		assert.True(t, nested, "CTE body table 'orders' should be nested")
+
+		nested, ok = nestedOf(ir, "ro")
+		require.True(t, ok, "expected CTE relation 'ro'")
+		assert.False(t, nested, "CTE reference 'ro' is a direct FROM relation")
+
+		nested, ok = nestedOf(ir, "customers")
+		require.True(t, ok, "expected base table 'customers'")
+		assert.False(t, nested, "joined base table 'customers' is a direct FROM relation")
+	})
+
+	t.Run("derived table body is nested, derived relation is not", func(t *testing.T) {
+		ir := parseAssertNoError(t, `SELECT * FROM (SELECT id FROM orders) sub WHERE sub.id > 1`)
+
+		nested, ok := nestedOf(ir, "orders")
+		require.True(t, ok, "expected nested base table 'orders'")
+		assert.True(t, nested, "derived-table body 'orders' should be nested")
+
+		nested, ok = nestedOf(ir, "sub")
+		require.True(t, ok, "expected derived relation 'sub'")
+		assert.False(t, nested, "derived relation 'sub' is a direct FROM relation")
+	})
+
+	t.Run("plain FROM tables are not nested", func(t *testing.T) {
+		ir := parseAssertNoError(t, `SELECT * FROM orders o JOIN customers c ON o.customer_id = c.id`)
+		for _, tbl := range ir.Tables {
+			assert.False(t, tbl.Nested, "plain FROM table %q should not be nested", tbl.Name)
+		}
+	})
+}
+
 func TestIR_CTEParsedQuery_Update(t *testing.T) {
 	sql := `WITH updated_users AS (
     UPDATE users SET active = true WHERE id = $1 RETURNING id

--- a/select.go
+++ b/select.go
@@ -36,9 +36,8 @@ func populateSelectFromResolved(result *ParsedQuery, withClause gen.IWith_clause
 		if len(ctes) > 0 {
 			result.CTEs = append(result.CTEs, ctes...)
 		}
-		// Add tables found within CTEs to the result
 		if len(cteTables) > 0 {
-			result.Tables = append(result.Tables, cteTables...)
+			result.Tables = append(result.Tables, markNested(cteTables)...)
 		}
 	}
 	for _, cte := range result.CTEs {
@@ -170,11 +169,16 @@ func extractCTEs(withCtx gen.IWith_clauseContext, tokens antlr.TokenStream) ([]C
 		if name == "" {
 			name = fmt.Sprintf("cte_%d", len(ctes)+1)
 		}
+		var columnAliases []string
+		if nl := cteCtx.Name_list_(); nl != nil {
+			columnAliases = nameListStrings(nl.Name_list(), tokens)
+		}
 		ctes = append(ctes, CTE{
-			Name:         name,
-			Query:        query,
-			ParsedQuery:  parsedQuery,
-			Materialized: materialized,
+			Name:          name,
+			Query:         query,
+			ParsedQuery:   parsedQuery,
+			Materialized:  materialized,
+			ColumnAliases: columnAliases,
 		})
 	}
 
@@ -341,8 +345,11 @@ func collectTableRefs(result *ParsedQuery, ref gen.ITable_refContext, tokens ant
 		// Build nested subquery analysis without flattening inner column usage
 		// into the parent query scope.
 		if subRef, err := buildSubqueryRef(alias, "FROM", sub, tokens); err == nil && subRef != nil {
+			if ac := ref.Alias_clause(); ac != nil {
+				subRef.ColumnAliases = nameListStrings(ac.Name_list(), tokens)
+			}
 			result.Subqueries = append(result.Subqueries, *subRef)
-			appendSetOpTables(result, nil, subRef.Query.Tables)
+			appendSetOpTables(result, nil, markNested(subRef.Query.Tables))
 		}
 	}
 

--- a/setops.go
+++ b/setops.go
@@ -297,7 +297,7 @@ func extractTablesAndUsageForPrimary(primary gen.ISimple_select_pramaryContext, 
 		// into the parent query scope.
 		if subRef, err := buildSubqueryRef("", "SETOP", primary.Select_with_parens(), tokens); err == nil && subRef != nil {
 			tmp.Subqueries = append(tmp.Subqueries, *subRef)
-			tmp.Tables = append(tmp.Tables, subRef.Query.Tables...)
+			tmp.Tables = append(tmp.Tables, markNested(subRef.Query.Tables)...)
 		}
 	}
 	return tmp.Tables, tmp.Subqueries


### PR DESCRIPTION
## Summary

Unqualified `WHERE` columns in multi-relation queries now resolve against the query's **direct** FROM relations, including CTEs and derived tables, instead of only base tables.

- New `TableRef.Nested` marks relations surfaced from inside a CTE or subquery body (set via `markNested` at the CTE/derived/set-op/MERGE flatten sites). Additive, default `false`; resolution considers only direct (`Nested==false`) relations, so a base table buried inside a CTE body is no longer mistaken for a FROM relation.
- `resolveColumnTableFromSchema` resolves a column against each direct relation: base tables via `schemaMap`, CTEs and derived tables via their projection. Exactly one match wins; zero or multiple leave `Table` empty. A `SELECT *` projection is opaque (forces ambiguity).
- Projection handling covers: declared column alias lists (`WITH t(a, b)`, `(...) sub(a, b)`) applied positionally (short lists rename only leading columns), casted columns (`total::numeric` stays `total`), and data-modifying CTE `RETURNING` lists (explicit and implicit aliases).

## Layer

- [x] Parser IR (`ir.go`, `select.go`, `setops.go`, `merge.go`, `dml_*.go`, `helpers.go`)
- [x] Analysis layer (`analysis/combined_extractor.go`, `analysis/where_conditions.go`)
- [x] Tests
- [x] Documentation

## SQL examples

```sql
WITH recent_orders AS (SELECT id, customer_id, total FROM orders)
SELECT * FROM recent_orders r JOIN customers c ON c.id = r.customer_id WHERE total > 100;
-- total resolves to "recent_orders" (the CTE), not the base "orders" inside the CTE body

SELECT * FROM (SELECT id, total FROM orders) sub JOIN customers c ON c.id = sub.id WHERE total > 100;
-- total resolves to "sub"

WITH t(x) AS (SELECT total FROM orders) SELECT * FROM t JOIN customers c ON c.id = 1 WHERE x > 1;
-- x resolves to "t"; "total" is hidden behind the alias list and stays unresolved
```

## Test plan

- [x] `TestExtractWhereConditionsWithSchema_CTEAndDerived` — CTE/derived resolution, base collisions, `SELECT *` opacity, alias lists (full and short), casts, `RETURNING` (explicit/implicit alias), and a direct-table-vs-subquery-body case.
- [x] `TestExtractWhereConditionsWithSchema_EmptyMapResolvesProjections` — empty (non-nil) map resolves CTE relations.
- [x] `TestIR_NestedTableMarking` — `Nested` set for CTE/subquery bodies, not for direct FROM relations.
- [x] Existing `TestExtractWhereConditionsWithSchema` (incl. the #75 self-join case) unchanged.
- [x] `go test -race -count=1 ./...`, `make vet`, `golangci-lint run` — all clean.
- [x] Reviewed locally with `codex review` across several rounds; all correctness findings addressed (see Notes).

## Behavioral impact

Additive. A nil `schemaMap` still behaves exactly like `ExtractWhereConditions` (no resolution). The new `Nested`/`ColumnAliases` IR fields are zero for existing consumers. The only change to resolved output is that columns which previously came back with an empty `Table` (or were misattributed to a nested base table) now resolve to the correct CTE/derived relation.

## Notes

- Self-joins (`FROM t a JOIN t b`) intentionally resolve to the shared relation name, matching the existing base-table behavior from #75 (repeats of one relation are not treated as ambiguous).
- When a directly-joined table is also read inside a subquery body, `appendSetOpTables` de-dups the nested duplicate by name. This does not affect resolution (the direct relation is always present with `Nested=false`); it only means the duplicated nested ref is not separately surfaced in `Tables`.

## Out of scope

- Resolving through nested CTE chains (a CTE selecting from another CTE).
- Inferring `SELECT *` projections from schema metadata.

## Related issues

Closes #77. Unblocks #79 (correlated-subquery detection), which depends on scope-aware table tracking.

## Checklist

- [x] No changes to `gen/` (auto-generated ANTLR code)
- [x] No exported signature changes (new struct fields only)
- [x] Documentation updated (`docs/parsed-query.md`)
