### PR TITLE
fix(ir): record INTERSECT right-hand WHERE column usage

### DIFF
--- a/parser_ir_setops_test.go
+++ b/parser_ir_setops_test.go
@@ -109,6 +109,24 @@ SELECT user_id FROM revoked_permissions`,
 	}
 }
 
+// TestIR_SetOpRHSWhereColumnUsage checks right-hand set-operation branches
+// record their WHERE filters exactly once; INTERSECT used to drop them.
+func TestIR_SetOpRHSWhereColumnUsage(t *testing.T) {
+	for _, op := range []string{"UNION", "INTERSECT", "EXCEPT"} {
+		t.Run(op, func(t *testing.T) {
+			ir := parseAssertNoError(t, "SELECT a FROM t1 WHERE x = 1 "+op+" SELECT a FROM t2 WHERE y = 2")
+
+			count := 0
+			for _, usage := range ir.ColumnUsage {
+				if usage.UsageType == ColumnUsageTypeFilter && strings.EqualFold(usage.Column, "y") {
+					count++
+				}
+			}
+			assert.Equal(t, 1, count, "expected RHS filter column y recorded exactly once")
+		})
+	}
+}
+
 // TestIR_SetOpBranchLimitIsNested guards the isNested flag propagation through
 // the consolidated populateSelectFromResolved entry-point: a LIMIT on the
 // top-level select must report IsNested=false, while a LIMIT inside a

--- a/setops.go
+++ b/setops.go
@@ -173,7 +173,7 @@ func collectIntersectOperationsWithResult(node gen.ISimple_select_intersectConte
 			continue
 		}
 
-		op, opSubs := buildSetOperationFromPrimary(opType, primary, tokens, cteNames)
+		op, opSubs := buildSetOperationFromPrimary(opType, primary, tokens, cteNames, result)
 		ops = append(ops, op)
 		subqueries = append(subqueries, opSubs...)
 		nestedOps, nestedLeading, nestedSubs := collectNestedSetOperationsFromPrimary(primary, tokens, cteNames)
@@ -206,8 +206,9 @@ func buildSetOperationFromIntersect(opType string, rhs gen.ISimple_select_inters
 }
 
 // buildSetOperationFromPrimary materialises metadata for an INTERSECT primary SELECT.
-func buildSetOperationFromPrimary(opType string, primary gen.ISimple_select_pramaryContext, tokens antlr.TokenStream, cteNames map[string]struct{}) (SetOperation, []SubqueryRef) {
-	tables, subqueries := extractTablesForPrimary(primary, tokens, cteNames)
+func buildSetOperationFromPrimary(opType string, primary gen.ISimple_select_pramaryContext, tokens antlr.TokenStream, cteNames map[string]struct{}, result *ParsedQuery) (SetOperation, []SubqueryRef) {
+	// Pass result through to capture column usage
+	tables, subqueries := extractTablesAndUsageForPrimary(primary, tokens, cteNames, result)
 	query := ""
 	query = text(tokens, primary)
 	return SetOperation{
@@ -249,11 +250,6 @@ func collectNestedSetOperationsFromPrimary(primary gen.ISimple_select_pramaryCon
 		return nil, nil, nil
 	}
 	return extractSetOperationsWithResult(inner, tokens, cteNames, nil)
-}
-
-// extractTablesForPrimary recovers table references and nested subqueries from a select primary.
-func extractTablesForPrimary(primary gen.ISimple_select_pramaryContext, tokens antlr.TokenStream, cteNames map[string]struct{}) ([]TableRef, []SubqueryRef) {
-	return extractTablesAndUsageForPrimary(primary, tokens, cteNames, nil)
 }
 
 // extractTablesAndUsageForPrimary recovers table references, subqueries, and column usage from a select primary.


### PR DESCRIPTION
## Summary

- INTERSECT right-hand branches were dropping their WHERE filters from `ColumnUsage`: `buildSetOperationFromPrimary` went through `extractTablesForPrimary`, which hard-coded a nil result, so the branch's comparisons were recorded into a throwaway query. UNION and EXCEPT already threaded the real result through.
- `buildSetOperationFromPrimary` now takes the result and calls `extractTablesAndUsageForPrimary` directly; the one-line `extractTablesForPrimary` wrapper is gone (it had no other callers).

## Layer

- [x] Core parser (`ir.go`, `ddl.go`, `select.go`, `dml_*.go`, `merge.go`, `setops.go`, `entry.go`)
- [ ] Analysis layer (`analysis/`)
- [ ] Docs / examples
- [ ] CI / tooling

## SQL examples

```sql
SELECT a FROM t1 WHERE x = 1 INTERSECT SELECT a FROM t2 WHERE y = 2
-- before: filter ColumnUsage has no y at all
-- after:  y = 2 recorded, same as the UNION/EXCEPT equivalents
```

## Test plan

- [x] New unit tests added
- [ ] Existing tests updated
- [x] `make test` passes (race detector + coverage)
- [x] `make vet` passes
- [ ] Manual verification with `examples/`

New `TestIR_SetOpRHSWhereColumnUsage` runs the same query under UNION, INTERSECT, and EXCEPT and asserts the RHS filter column shows up exactly once for each.

## Related issues

None.

## Checklist

- [x] No changes to `gen/` (auto-generated ANTLR code)
- [x] New IR fields documented in `docs/parsed-query.md` (if applicable) — no new fields
- [x] Public API additions are backward compatible — no API changes
