### PR TITLE
fix(ir): record leading set-op branch WHERE usage once

### DIFF
--- a/parser_ir_setops_test.go
+++ b/parser_ir_setops_test.go
@@ -109,20 +109,23 @@ SELECT user_id FROM revoked_permissions`,
 	}
 }
 
-// TestIR_SetOpRHSWhereColumnUsage checks right-hand set-operation branches
-// record their WHERE filters exactly once; INTERSECT used to drop them.
-func TestIR_SetOpRHSWhereColumnUsage(t *testing.T) {
+// TestIR_SetOpWhereColumnUsage checks each set-operation branch records its
+// WHERE filter exactly once; the leading branch used to be recorded twice and
+// INTERSECT right-hand branches not at all.
+func TestIR_SetOpWhereColumnUsage(t *testing.T) {
 	for _, op := range []string{"UNION", "INTERSECT", "EXCEPT"} {
 		t.Run(op, func(t *testing.T) {
 			ir := parseAssertNoError(t, "SELECT a FROM t1 WHERE x = 1 "+op+" SELECT a FROM t2 WHERE y = 2")
 
-			count := 0
-			for _, usage := range ir.ColumnUsage {
-				if usage.UsageType == ColumnUsageTypeFilter && strings.EqualFold(usage.Column, "y") {
-					count++
+			for _, col := range []string{"x", "y"} {
+				count := 0
+				for _, usage := range ir.ColumnUsage {
+					if usage.UsageType == ColumnUsageTypeFilter && strings.EqualFold(usage.Column, col) {
+						count++
+					}
 				}
+				assert.Equal(t, 1, count, "expected filter column %s recorded exactly once", col)
 			}
-			assert.Equal(t, 1, count, "expected RHS filter column y recorded exactly once")
 		})
 	}
 }

--- a/setops.go
+++ b/setops.go
@@ -65,8 +65,7 @@ func extractSetOperationsWithResult(selectNoParens gen.ISelect_no_parensContext,
 		// Otherwise it was already processed by extractWhereClause in the main SELECT
 		if hasSetOps {
 			if primary := first.Simple_select_pramary(0); primary != nil {
-				// Pass result through to capture column usage from first SELECT
-				firstTables, firstSubs := extractTablesAndUsageForPrimary(primary, tokens, cteNames, result)
+				firstTables, firstSubs := extractTablesAndUsageForPrimary(primary, tokens, cteNames, nil)
 				leading = append(leading, firstTables...)
 				subqueries = append(subqueries, firstSubs...)
 			}


### PR DESCRIPTION
## Summary

- The leading branch of a UNION/INTERSECT/EXCEPT had its WHERE filters recorded twice in `ColumnUsage`: once by the main SELECT flow (`extractWhereClause`), and again when `extractSetOperationsWithResult` re-extracted the same primary with the live result.
- The set-op pass now extracts the leading primary without the result container — it only needs the branch's tables there, and `appendSetOpTables` already dedups those. Right-hand branch recording (#86) is untouched.

## Layer

- [x] Core parser (`ir.go`, `ddl.go`, `select.go`, `dml_*.go`, `merge.go`, `setops.go`, `entry.go`)
- [ ] Analysis layer (`analysis/`)
- [ ] Docs / examples
- [ ] CI / tooling

## SQL examples

```sql
SELECT a FROM t1 WHERE x = 1 UNION SELECT a FROM t2 WHERE y = 2
-- before: filter ColumnUsage lists x twice, y once
-- after:  x once, y once
```

## Test plan

- [x] New unit tests added
- [x] Existing tests updated
- [x] `make test` passes (race detector + coverage)
- [x] `make vet` passes
- [ ] Manual verification with `examples/`

`TestIR_SetOpRHSWhereColumnUsage` grew into `TestIR_SetOpWhereColumnUsage`: it now asserts BOTH branches' filter columns appear exactly once, for all three operators.

## Related issues

Follow-up to #86 — same code path, opposite failure mode.

## Checklist

- [x] No changes to `gen/` (auto-generated ANTLR code)
- [x] New IR fields documented in `docs/parsed-query.md` (if applicable) — no new fields
- [x] Public API additions are backward compatible — no API changes