### PR TITLE
fix(ir): stop duplicating leading set-op FROM subqueries

### DIFF
--- a/parser_ir_setops_test.go
+++ b/parser_ir_setops_test.go
@@ -130,6 +130,22 @@ func TestIR_SetOpWhereColumnUsage(t *testing.T) {
 	}
 }
 
+// TestIR_SetOpLeadingFromSubqueryOnce checks a FROM subquery in the leading
+// set-op branch appears once in Subqueries; it used to be recorded twice.
+func TestIR_SetOpLeadingFromSubqueryOnce(t *testing.T) {
+	ir := parseAssertNoError(t, "SELECT a FROM (SELECT a FROM inner_t) s WHERE x = 1 UNION SELECT a FROM t2 WHERE y = 2")
+
+	count := 0
+	for _, sq := range ir.Subqueries {
+		if sq.SourceClause == "FROM" && sq.Alias == "s" {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count, "expected leading FROM subquery recorded exactly once")
+	assert.True(t, containsTable(ir.Tables, "inner_t"), "expected inner_t surfaced in top-level tables")
+	assert.True(t, containsTable(ir.Tables, "t2"), "expected t2 surfaced in top-level tables")
+}
+
 // TestIR_SetOpBranchLimitIsNested guards the isNested flag propagation through
 // the consolidated populateSelectFromResolved entry-point: a LIMIT on the
 // top-level select must report IsNested=false, while a LIMIT inside a

--- a/setops.go
+++ b/setops.go
@@ -11,6 +11,7 @@ import (
 )
 
 // extractSetOperationsWithResult traverses UNION/INTERSECT/EXCEPT chains with optional result for column usage recording.
+// A leading primary with its own FROM clause is skipped: the main SELECT flow already extracts it fully.
 func extractSetOperationsWithResult(selectNoParens gen.ISelect_no_parensContext, tokens antlr.TokenStream, cteNames map[string]struct{}, result *ParsedQuery) ([]SetOperation, []TableRef, []SubqueryRef) {
 	if selectNoParens == nil {
 		return nil, nil, nil
@@ -61,10 +62,8 @@ func extractSetOperationsWithResult(selectNoParens gen.ISelect_no_parensContext,
 	}
 
 	if first := clauseCtx.Simple_select_intersect(0); first != nil {
-		// Only process the first primary if there are actual set operations
-		// Otherwise it was already processed by extractWhereClause in the main SELECT
 		if hasSetOps {
-			if primary := first.Simple_select_pramary(0); primary != nil {
+			if primary := first.Simple_select_pramary(0); primary != nil && primary.From_clause() == nil {
 				firstTables, firstSubs := extractTablesAndUsageForPrimary(primary, tokens, cteNames, nil)
 				leading = append(leading, firstTables...)
 				subqueries = append(subqueries, firstSubs...)


### PR DESCRIPTION
## Summary

- When a set operation's leading branch had a FROM subquery, it landed in `Subqueries` twice: once from the main SELECT flow, once from the set-op pass re-extracting the same primary. Tables were saved by dedup in `appendSetOpTables`, but `Subqueries` has no dedup.
- The set-op pass now skips the leading primary when it has its own FROM clause — the main flow already extracted everything from it. `TABLE t` and parenthesized leading branches (which the main flow can't reach) are still processed there.

## Layer

- [x] Core parser (`ir.go`, `ddl.go`, `select.go`, `dml_*.go`, `merge.go`, `setops.go`, `entry.go`)
- [ ] Analysis layer (`analysis/`)
- [ ] Docs / examples
- [ ] CI / tooling

## SQL examples

```sql
SELECT customer_id, total
FROM (SELECT customer_id, SUM(amount) AS total FROM orders GROUP BY customer_id) spenders
WHERE total > 1000
UNION
SELECT customer_id, credit_limit FROM vip_accounts WHERE region = 'EU';

-- ir.Subqueries before: [spenders, spenders]  (two identical FROM entries)
-- ir.Subqueries after:  [spenders]
```

A consumer walking `Subqueries` to enumerate derived tables previously visited `spenders` twice — anything counting, indexing, or generating per-subquery output did double work on set-operation queries.

## Test plan

- [x] New unit tests added
- [ ] Existing tests updated
- [x] `make test` passes (race detector + coverage)
- [x] `make vet` passes
- [ ] Manual verification with `examples/`

New `TestIR_SetOpLeadingFromSubqueryOnce` pins the subquery to exactly one entry and checks both branch tables still surface. Existing set-op tests (parenthesized leading branches, `Nested` LIMIT flags, table capture) cover the paths that must keep going through the set-op extraction.

## Related issues

Same double-extraction family as #87.

## Checklist

- [x] No changes to `gen/` (auto-generated ANTLR code)
- [x] New IR fields documented in `docs/parsed-query.md` (if applicable) — no new fields
- [x] Public API additions are backward compatible — no API changes
